### PR TITLE
Implemented convert Markdown code into HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.19.0",
-        "@types/node": "^22.13.5",
+        "@types/node": "^22.13.9",
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",
         "@vitejs/plugin-react": "^1.3.2",
@@ -1673,9 +1673,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.8.tgz",
-      "integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
+      "version": "22.13.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
+      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
-    "@types/node": "^22.13.5",
+    "@types/node": "^22.13.9",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint:md": "markdownlint '**/*.md' --ignore-path .prettierignore",
     "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,json,css,md}'",
     "format:file": "prettier --write",
-    "format:check": "prettier --check 'src/**/*.{js,jsx,ts,tsx,json,css,md}'"
+    "format:check": "prettier --check 'src/**/*.{js,jsx,ts,tsx,json,css,md}'",
+    "test:md": "ts-node --esm src/tests/mdparser-utils.test.ts"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.0.4",

--- a/src/tests/mdparser-utils.test.ts
+++ b/src/tests/mdparser-utils.test.ts
@@ -1,0 +1,12 @@
+import { renderMarkdown } from '../utils/mdparser-utils.ts';
+
+const sampleMarkdown = `
+Here is a code example:
+
+\`\`\`javascript
+console.log("Hello, world!");
+\`\`\`
+`;
+
+const htmlOutput = renderMarkdown(sampleMarkdown);
+console.log(htmlOutput);

--- a/src/utils/mdparser-utils.ts
+++ b/src/utils/mdparser-utils.ts
@@ -165,6 +165,12 @@ export const renderMarkdown = (markdown: string): string => {
     '<code class="bg-gray-100 px-1 py-0.5 rounded text-sm font-mono">$1</code>',
   );
 
+  // Convert code blocks
+  html = html.replace(/```(.*?)\n([\s\S]*?)```/g, function (_, lang, code) {
+    const languageClass = lang ? `language-${lang}` : '';
+    return `<pre class="bg-gray-900 text-white p-4 rounded-md overflow-auto"><code class="${languageClass}">${escapeHtml(code)}</code></pre>`;
+  });
+
   // Improved table handling
   const tableRegex = /^\|(.+)\|(\r?\n\|[-|\s]+\|)(\r?\n\|.+\|)+/gm;
   html = html.replace(tableRegex, function (match) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
### Title:  Implemented convert Markdown code blocks into HTML format


### Description
This PR enhances the existing Markdown parser (src/utils/mdparser-utils.ts) by adding support for converting code blocks from Markdown to HTML. 

This PR fixes #19 

## Checklist
- [ ] I have tested these changes locally and they work as expected.
