### PR TITLE
Fixed Try Now Button

### DIFF
--- a/src/sections/Header.tsx
+++ b/src/sections/Header.tsx
@@ -225,7 +225,7 @@ const Header: React.FC = () => {
                             flex flex-col h-screen overflow-y-auto"
                 >
                   <div className="h-20" />
-                  <div style={{flexGrow:0.85,flexShrink:1,flexBasis:0}}className="overflow-y-auto overscroll-contain px-4 py-6">
+                  <div className="flex-grow-[0.7] flex-shrink flex-basis-0 overflow-y-auto overscroll-contain px-4 py-6">
                     <div className="space-y-6">
                       {Object.entries(dropdowns).map(
                         ([key, { label, items }]) => (

--- a/src/sections/Header.tsx
+++ b/src/sections/Header.tsx
@@ -222,10 +222,10 @@ const Header: React.FC = () => {
                   exit={{ opacity: 0, x: '100%' }}
                   transition={{ type: 'tween', duration: 0.3 }}
                   className="fixed md:hidden top-0 right-0 bottom-0 w-[80%] max-w-sm bg-white shadow-xl z-40
-                            flex flex-col h-screen overflow-y-auto"
+                            flex flex-col h-[90vh] overflow-y-auto"
                 >
                   <div className="h-20" />
-                  <div className="flex-grow-[0.7] flex-shrink flex-basis-0 overflow-y-auto overscroll-contain px-4 py-6">
+                  <div className="flex-grow-1 overflow-y-auto overscroll-contain px-4 py-6">
                     <div className="space-y-6">
                       {Object.entries(dropdowns).map(
                         ([key, { label, items }]) => (

--- a/src/sections/Header.tsx
+++ b/src/sections/Header.tsx
@@ -225,7 +225,7 @@ const Header: React.FC = () => {
                             flex flex-col h-screen overflow-y-auto"
                 >
                   <div className="h-20" />
-                  <div className="flex-1 overflow-y-auto overscroll-contain px-4 py-6">
+                  <div style={{flexGrow:0.85,flexShrink:1,flexBasis:0}}className="overflow-y-auto overscroll-contain px-4 py-6">
                     <div className="space-y-6">
                       {Object.entries(dropdowns).map(
                         ([key, { label, items }]) => (


### PR DESCRIPTION
---
Name: Try Now Not Visible
about: Fixed Try Now Button Visibility in Mobiles
---

## Description

<!--- Describe the changes introduced by this pull request. -->
I have made the Menu Bar div a bit small so that the Try Now button has space to be visible for the user.
<!--- Explain what problem it solves or what feature/fix it adds. -->
Mobile browsers varies in having the tab menu below the browser. The issue was that the Try Now button was not visible for browsers with the tab menu at the bottom of the screen. i fixed it by moving the button a bit upwards, so that the button is visible for every mobile user, irrespective of the browser they use.

## Related Issue

<!--- If this pull request is related to a specific issue, reference it here using #issue_number. -->
<!--- For example, "Fixes #123" or "Addresses #456". -->

This PR fixes #30 

## Changes Made

<!--- Provide a summary of the changes made in this pull request. -->
<!--- Include any relevant technical details or architecture changes. -->

- Made the Menu Bar div from flex-grow:1 to flex-grow:0.7

## Testing Performed

<!--- Describe the testing that you have performed to validate these changes. -->
<!--- Include information about test cases, testing environments, and results. -->

- Tested the website on browsers, both with and without tab menu at the bottom.

## Additional Notes for Reviewers

<!--- Provide any additional context or notes for the reviewers. -->
<!--- This might include details about design decisions, potential concerns, or anything else relevant. -->
Please provide any suggestions or feedback regarding the submission made. Thank You!
---
## Results

- Browser with Tab Menu

![WhatsApp Image 2025-03-12 at 13 11 08_f86d84cc](https://github.com/user-attachments/assets/0232fa92-d69d-40ef-9d9c-65914e669033)
-Browser without Tab Menu

![WhatsApp Image 2025-03-12 at 13 11 08_4fdce7aa](https://github.com/user-attachments/assets/64c62899-2b58-4131-b36f-d8faa8a01b7d)
