### PR TITLE
Rendered Links on Volunteer Page

### DIFF
--- a/src/pages/Volunteer.tsx
+++ b/src/pages/Volunteer.tsx
@@ -10,6 +10,7 @@ import {
   slideInBottom,
   cardFadeIn,
 } from '@/styles/Animations';
+import { Link } from 'react-router-dom';
 
 const Volunteer = () => {
   return (
@@ -194,7 +195,7 @@ const Volunteer = () => {
 
           <p className="text-lg text-gray-700 font-[Inter] mt-6 leading-relaxed">
             Feel free to reach out to express your interest in volunteering via
-            email or Matrix. Alternatively, you may send a direct message to one
+            <Link style={{ color: '#007bff' }} to={"mailto:info@sugarlabs.org"}> email </Link> or <Link style={{ color: '#007bff' }} to={"https://matrix.to/#/#sugar:matrix.org"}> Matrix </Link>. Alternatively, you may send a <Link style={{ color: '#007bff' }} to={"/contact-us"}> direct message </Link> to one
             of our social media channels.
           </p>
         </motion.div>


### PR DESCRIPTION
---
name: Rendered Links on Volunteer Page
about: Added Links Mentioned In the issue and verified Functionality
---

## Description

Add email, Matrix and DM link on the Last Section OF "Join Volunteer" page.
and  the DM link should lead us to the CONTACT US page.

## Related Issue

<!--- If this pull request is related to a specific issue, reference it here using #issue_number. -->
<!--- For example, "Fixes #123" or "Addresses #456". -->

This PR fixes #106 

## Changes Made

Added Links for the email,contact and matrix 
Also added Custom Link color same as in the older version of site
Used Link Component for Linking

- Added Links of Contact,Matrix,Mail
- added Color To make it appear Like a Link (Same Color as in the previous Site Links Color )


## Testing Performed

- Verified that the development server (npm run dev) runs without errors


## Checklist

- [X] I have tested these changes locally and they work as expected.
- [X] I have added/updated tests that prove the effectiveness of these changes.
- [X] I have followed the project's coding style guidelines.


## Additional Notes for Reviewers

Please Rectify or do let me know if any thing better can be done .

---

