### PR TITLE
fix: website rendering on OLPC Operating System

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,8 +6,8 @@ import '@/utils/copy-code';
 
 const browserType = window.navigator.userAgent;
 
-if (browserType === "OLPC") {
-  window.location.href = "redirect to old website";
+if (browserType.includes("Chromium/23.0.1271.95")) {
+  window.location.href = "https://sugarlabs.github.io/www/";
 }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,12 @@ import App from '@/App';
 import '@/styles/globals.css';
 import '@/utils/copy-code';
 
+const browserType = window.navigator.userAgent;
+
+if (browserType === "OLPC") {
+  window.location.href = "redirect to old website";
+}
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
fixes #128 
@quozl Can you please run `const browserType = window.navigator.userAgent; console.log(browserType);` in browser console and provide me with the string. We can then replace it with "OLPC".
By doing this "OLPC XO-4 and OLPC OS 13.2.11" would be able to see old website whereas new browsers will be able to see new website.
This approach was discussed with @pikurasa in last meet.