### PR TITLE
Fix author file path for Saumya Shahi in blog post

### DIFF
--- a/src/constants/MarkdownFiles/posts/2025-06-14-gsoc-25-saumya-week02.md
+++ b/src/constants/MarkdownFiles/posts/2025-06-14-gsoc-25-saumya-week02.md
@@ -4,7 +4,7 @@ excerpt: "This week focused on documenting the brick tree structure, refining SV
 category: "DEVELOPER NEWS"
 date: "2025-06-14"
 slug: "2025-06-14-gsoc-25-saumya-shahi-week02"
-author: "@/constants/MarkdownFiles/authors/saumyashahi.md"
+author: "@/constants/MarkdownFiles/authors/saumya-shahi.md"
 tags: "gsoc25,sugarlabs,week02,saumya-shahi"
 image: "assets/Images/GSOC.png"
 ---


### PR DESCRIPTION
This commit updates the blog post frontmatter to correctly reference the author file:
- Changed `author` from `saumyashahi.md` to `saumya-shahi.md` to match the actual path.
- Ensures the author metadata renders properly on the GSoC blog post page.

Tested locally and verified metadata displays as expected.
