### PR TITLE
Changed the Images disply in News Page of cards

### DIFF
--- a/src/pages/News/NewsPage.tsx
+++ b/src/pages/News/NewsPage.tsx
@@ -451,7 +451,7 @@ const NewsPage: React.FC = () => {
                           <img
                             src={post.image}
                             alt={post.title}
-                            className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700"
+                            className="w-full h-full object-contains group-hover:scale-110 transition-transform duration-700"
                           />
                         ) : (
                           <div className="w-full h-full bg-gradient-to-br from-blue-100 via-purple-50 to-green-100 flex items-center justify-center">
@@ -521,7 +521,7 @@ const NewsPage: React.FC = () => {
             <div className="flex justify-center">
               <motion.button
                 onClick={handleShowMore}
-                className="relative px-8 py-4 bg-gradient-to-r from-blue-600 to-green-600 text-white hover:from-blue-700 hover:to-green-700 transition-all duration-300 rounded-2xl shadow-lg hover:shadow-2xl font-medium flex items-center gap-3 group overflow-hidden"
+                className="relative px-8 py-4 bg-gradient-to-r from-blue-600 to-green-600 text-white hover:from-blue-700 hover:to-green-700 cursor-pointer transition-all duration-300 rounded-2xl shadow-lg hover:shadow-2xl font-medium flex items-center gap-3 group overflow-hidden"
                 variants={bounce}
                 initial="hidden"
                 animate="visible"


### PR DESCRIPTION
Changed the Images disply in News Page of cards. and Make the cursor pointer when we hover on the button

---
name: Pull Request
about: Changed the display of the Images on cards in News page and make the cursor pointer when we hover on the button
---

## Description

The cards of the News Page have images which are not alligned properly, they are overflowing than the card size. Fixed this by making the image fit inside the card itself. 
Made the "Load More Articles" button cursor poniter when we hover on them

## Related Issue

This PR fixes #285 

## After
![Screenshot 2025-07-07 182929](https://github.com/user-attachments/assets/38faa722-8970-4107-a3f3-2084152e3f3c)

## Before
![image](https://github.com/user-attachments/assets/46df9b7a-8429-4ddc-b17a-e1f4dffb62d7)


## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes for Reviewers

<!--- Provide any additional context or notes for the reviewers. -->
<!--- This might include details about design decisions, potential concerns, or anything else relevant. -->

---

Thank you for contributing to our project! We appreciate your help in improving it.

📚 See [contributing instructions](https://github.com/sugarlabs/musicblocks/blob/master/README.md).

🙋🏾🙋🏼 Questions: [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org).
