### PR TITLE
fix #344: the notification badge made unclipped

### DIFF
--- a/src/pages/News/NewsPage.tsx
+++ b/src/pages/News/NewsPage.tsx
@@ -521,7 +521,7 @@ const NewsPage: React.FC = () => {
             <div className="flex justify-center">
               <motion.button
                 onClick={handleShowMore}
-                className="relative px-8 py-4 bg-gradient-to-r from-blue-600 to-green-600 text-white hover:from-blue-700 hover:to-green-700 cursor-pointer transition-all duration-300 rounded-2xl shadow-lg hover:shadow-2xl font-medium flex items-center gap-3 group overflow-hidden"
+                className="relative px-8 py-4 bg-gradient-to-r from-blue-600 to-green-600 text-white hover:from-blue-700 hover:to-green-700 cursor-pointer transition-all duration-300 rounded-2xl shadow-lg hover:shadow-2xl font-medium flex items-center gap-3 group"
                 variants={bounce}
                 initial="hidden"
                 animate="visible"


### PR DESCRIPTION
This PR fixes the yellow notification badge on the "Load More Articles" Button and allowed it to overflow to look better.

fixes #344

Screenshot of button after fix: 

<img width="430" height="217" alt="Screenshot 2025-07-29 at 7 21 06 PM" src="https://github.com/user-attachments/assets/e377a4f5-e1cb-479e-9337-a596c76a666d" />
