### PR TITLE
add report blogs for gsoc 2025 masonry module

### DIFF
--- a/src/constants/MarkdownFiles/posts/2025-07-26-gsoc-25-saumya-week-07-08.md
+++ b/src/constants/MarkdownFiles/posts/2025-07-26-gsoc-25-saumya-week-07-08.md
@@ -1,0 +1,80 @@
+---
+title: "GSoC '25 Week 07–08 Update by Saumya Shahi"
+excerpt: "This period focused on implementing tower disconnections, dynamic updates, and improving parent–child relationship logic in the Masonry system."
+category: "DEVELOPER NEWS"
+date: "2025-07-26"
+slug: "2025-07-26-gsoc-25-saumya-shahi-week07-08"
+author: "@/constants/MarkdownFiles/authors/saumya-shahi.md"
+tags: "gsoc25,sugarlabs,week07-08,saumya-shahi"
+image: "assets/Images/GSOC.webp"
+---
+
+# Week 07–08 Progress Report by Saumya Shahi
+
+**Project:** [Masonry Module - Music Blocks v4](https://github.com/sugarlabs/musicblocks-v4)  
+**Mentors:** [Anindya Kundu](https://github.com/meganindya/)  
+**Assisting Mentors:** [Walter Bender](https://github.com/walterbender), [Devin Ulibarri](https://github.com/pikurasa)  
+**Reporting Period:** 2025-07-13 – 2025-07-26  
+
+---
+
+## Goals for This Period
+
+- Add logic for **tower disconnections** inside the workspace.  
+- Update **parent-child relationships dynamically** during disconnections.  
+- Ensure bounding box recalculation after a brick or sub-tower is updated.  
+- Test system robustness by dragging bricks/towers in real-time.  
+
+---
+
+## This Week's Achievements
+
+1. **Tower Disconnection Logic**  
+   - Implemented drag-to-disconnect functionality for individual bricks and groups of bricks.  
+   - Towers split automatically into sub-towers while maintaining valid structure.  
+
+2. **Dynamic Parent–Child Updates**  
+   - Ensured that when a child brick is removed, its parent updates both **dimensions** and **connection slots** immediately.  
+   - Recalculated bounding boxes to avoid rendering issues.  
+
+3. **Workspace Testing**  
+   - Drag-and-drop now supports real-time snapping and real-time disconnection.  
+   - Added visual rejection markers when an invalid disconnection was attempted.  
+
+4. **Visual Verification**  
+   - Verified behavior in Storybook and Playground.  
+   - Example: Disconnected compound towers re-render correctly as separate trees.  
+
+---
+
+## Challenges & How I Overcame Them
+
+- **Challenge:** Recursive updates caused performance slowdowns for nested towers.  
+**Solution:** Optimized traversal using cached dimensions and partial recalculations.  
+
+- **Challenge:** Handling simultaneous drag of sub-towers with expressions.  
+**Solution:** Added special-case handling for expression slots and adjusted the bounding box calculation.  
+
+---
+
+## Key Learnings
+
+- Gained deeper insight into **tree traversal optimizations**.  
+- Understood edge cases in **drag-and-drop UX**.  
+- Strengthened knowledge of **React state management (Recoil)** for dynamic updates.  
+
+
+---
+
+## Resources & References
+
+- **Tower Utils:** [GitHub PR](https://github.com/sugarlabs/musicblocks-v4/pull/450)  
+- **Drag-and-Drop Docs:** [React Aria DnD](https://react-spectrum.adobe.com/react-aria/useDrag.html)  
+
+---
+
+## Acknowledgments
+
+Thank you to my mentors, the Sugar Labs community, and fellow GSoC contributors for your ongoing support and feedback.
+
+---

--- a/src/constants/MarkdownFiles/posts/2025-08-09-gsoc-25-saumya-week09-10.md
+++ b/src/constants/MarkdownFiles/posts/2025-08-09-gsoc-25-saumya-week09-10.md
@@ -1,0 +1,69 @@
+---
+title: "GSoC '25 Week 09–10 Update by Saumya Shahi"
+excerpt: "This phase focused on defining configurations for AST integration and refining the execution pipeline for Music Blocks v4."
+category: "DEVELOPER NEWS"
+date: "2025-08-09"
+slug: "2025-08-09-gsoc-25-saumya-shahi-week09-10"
+author: "@/constants/MarkdownFiles/authors/saumya-shahi.md"
+tags: "gsoc25,sugarlabs,week09-10,saumya-shahi"
+image: "assets/Images/GSOC.webp"
+---
+
+# Week 09–10 Progress Report by Saumya Shahi
+
+**Project:** [Masonry Module - Music Blocks v4](https://github.com/sugarlabs/musicblocks-v4)  
+**Mentors:** [Anindya Kundu](https://github.com/meganindya/)  
+**Assisting Mentors:** [Walter Bender](https://github.com/walterbender), [Devin Ulibarri](https://github.com/pikurasa)  
+**Reporting Period:** 2025-07-27 – 2025-08-09  
+
+---
+
+## Goals for This Period
+
+- Define AST mapping configuration for each brick type.  
+- Support translation for multiple AST node types (expressions, statements, functions).  
+- Validate execution pipeline by passing ASTs into the engine.  
+- Fix bugs and inconsistencies in previous tower logic.  
+
+---
+
+## This Week's Achievements
+
+1. **AST Translation Layer**  
+   - Built configuration-driven mapping from **visual bricks → AST nodes**.  
+   - Supported 26 AST node types, e.g., `FunctionCallStatement`, `BinaryOperatorExpression`.  
+   - Ensured expressions nested within compound bricks translated recursively. 
+
+2. **Bug Fixes & Refactoring**  
+   - Refactored tower utilities for more modularity.  
+   - Fixed multiple configuration inconsistencies that surfaced during AST export.  
+
+---
+
+## Challenges & How I Overcame Them
+
+- **Challenge:** Recursive expression mapping created circular references in early tests.  
+**Solution:** Added validation passes to prune invalid children before generating the AST.  
+
+---
+
+## Key Learnings
+
+- Stronger understanding of **AST structure and compiler pipelines**.  
+- Learned importance of **data validation** before execution.  
+- Improved debugging skills across **model-view-execution layers**.  
+
+---
+
+## Resources & References
+
+- **Music Blocks AST Specs** [Documentation done with peers](https://docs.google.com/document/d/1_MCCgl-RqiEQH0UQ4EX-2O6G4iRxgHAY1rZpw3QPXT0/edit?tab=t.otbw6ldsc32w) 
+- **AST Documentation:** [Mozilla AST Reference](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Parser_API)  
+
+---
+
+## Acknowledgments
+
+Thank you to my mentors, the Sugar Labs community, and fellow GSoC contributors for your ongoing support and feedback.
+
+---

--- a/src/constants/MarkdownFiles/posts/2025-08-24-gsoc-25-saumya-shahi-final.md
+++ b/src/constants/MarkdownFiles/posts/2025-08-24-gsoc-25-saumya-shahi-final.md
@@ -1,0 +1,79 @@
+---
+title: "GSoC '25 Final Wrap-Up by Saumya Shahi"
+excerpt: "Summarizing my GSoC 2025 journey: building the Masonry Module for Music Blocks v4, key results, challenges, and reflections."
+category: "DEVELOPER NEWS"
+date: "2025-08-24"
+slug: "2025-08-24-gsoc-25-saumya-shahi-final"
+author: "@/constants/MarkdownFiles/authors/saumya-shahi.md"
+tags: "gsoc25,sugarlabs,final,saumya-shahi"
+image: "assets/Images/GSOC.webp"
+---
+
+# Final Wrap-Up Report by Saumya Shahi
+
+**Project:** [Masonry Module - Music Blocks v4](https://github.com/sugarlabs/musicblocks-v4)  
+**Mentors:** [Anindya Kundu](https://github.com/meganindya/)  
+**Assisting Mentors:** [Walter Bender](https://github.com/walterbender), [Devin Ulibarri](https://github.com/pikurasa)  
+**Reporting Period:** 2025-08-10 – 2025-08-24  
+
+---
+
+## Goals for the Wrap-up
+
+- Finalize bug fixes, polish UI, and stabilize interactions.  
+- Prepare project documentation and final report.  
+- Write retrospective blog summarizing the entire journey.  
+
+---
+
+## Achievements
+
+1. **Final Integration**  
+   - Combined **brick rendering, palette, drag-and-drop, disconnections, and AST mapping** into one cohesive system.  
+   - Verified functionality across simple, expression, and compound brick types.  
+
+2. **Documentation**  
+   - Wrote detailed documentation covering architecture, utilities, and developer setup.  
+   - Submitted final report for GSoC archives.  
+
+3. **Community Contribution**  
+   - Collaborated with fellow contributors for bug fixes.  
+   - Received valuable feedback from mentors on UX design and technical choices.  
+
+---
+
+## Challenges
+
+- Balancing **scope creep** vs. realistic deliverables.  
+- Optimizing performance for larger towers with nested bricks.  
+- Ensuring seamless UX across all brick interactions.  
+
+---
+
+## Key Learnings
+
+- Designing for **scalability** is as important as delivering features.  
+- Collaboration and feedback loops are critical for open-source success.  
+- Improved knowledge in **React, SVG, ASTs, and data structure optimizations**.  
+
+---
+
+## Reflections
+
+> GSoC 2025 has been transformative. From learning how to render scalable SVG paths to building a full drag-and-drop visual programming system, this project taught me both technical depth and collaborative spirit.  
+
+This work will help future learners explore music and coding in a playful, powerful way.  
+
+---
+
+## Resources & References
+
+- **Project Repo:** [Music Blocks v4](https://github.com/sugarlabs/musicblocks-v4)  
+
+---
+
+## Acknowledgments
+
+Deep gratitude to my mentors **Anindya Kundu, Walter Bender, and Devin Ulibarri** for their guidance. Special thanks to the **Sugar Labs community** for encouragement and support throughout my GSoC journey.
+
+---


### PR DESCRIPTION
## Summary  
This PR adds the remaining **GSoC '25 blog posts** for my project **Masonry Module - Music Blocks v4** under Sugar Labs. These posts document my work during the final phases of GSoC:

## Changes Introduced  
-  Added **Week 07–08 Blog** (`2025-07-26-gsoc-25-saumya-shahi-week07-08.md`)  
-  Added **Week 09–10 Blog** (`2025-08-09-gsoc-25-saumya-shahi-week09-10.md`)  
-  Added **Final Wrap-Up Blog** (`2025-08-24-gsoc-25-saumya-shahi-final.md`)  
