### PR TITLE
fixed category navigation

### DIFF
--- a/src/pages/News/NewsDetailPage.tsx
+++ b/src/pages/News/NewsDetailPage.tsx
@@ -87,12 +87,14 @@ const NewsDetailPage: React.FC = () => {
 
   const handleGoBack = useCallback(() => {
     const search = location.search || '';
-    if (category) {
-      navigate(`/news/${category}${search}`);
-    } else {
-      navigate(`/news/community-news${search}`);
-    }
-  }, [navigate, category, location.search]);
+    // Prefer the category in the URL. If absent, derive from the post's category; fallback to 'all'.
+    const derivedCategory = category
+      ? category
+      : post?.category
+        ? post.category.toLowerCase().replace(/\s+/g, '-')
+        : 'all';
+    navigate(`/news/${derivedCategory}${search}`);
+  }, [navigate, category, location.search, post?.category]);
 
   const closeImageModal = useCallback(() => {
     setModalImage(null);

--- a/src/pages/News/NewsPage.tsx
+++ b/src/pages/News/NewsPage.tsx
@@ -68,7 +68,6 @@ const NewsPage: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    // Don't decide active category until categories have been loaded
     if (!categories.length) return;
     if (categoryParam) {
       const formatted = categoryParam.toLowerCase().replace(/-/g, ' ').trim();
@@ -89,7 +88,6 @@ const NewsPage: React.FC = () => {
   }, [location.search]);
 
   useEffect(() => {
-    // Wait until posts/categories load before syncing URL to avoid overwriting category from URL
     if (!categories.length) return;
     const pathCat =
       activeCategory === 'All'

--- a/src/pages/News/NewsPage.tsx
+++ b/src/pages/News/NewsPage.tsx
@@ -68,6 +68,8 @@ const NewsPage: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    // Don't decide active category until categories have been loaded
+    if (!categories.length) return;
     if (categoryParam) {
       const formatted = categoryParam.toLowerCase().replace(/-/g, ' ').trim();
       const match = categories.find((cat) => cat.toLowerCase() === formatted);
@@ -87,6 +89,8 @@ const NewsPage: React.FC = () => {
   }, [location.search]);
 
   useEffect(() => {
+    // Wait until posts/categories load before syncing URL to avoid overwriting category from URL
+    if (!categories.length) return;
     const pathCat =
       activeCategory === 'All'
         ? 'all'
@@ -94,7 +98,7 @@ const NewsPage: React.FC = () => {
     const query = searchTerm ? `?q=${encodeURIComponent(searchTerm)}` : '';
     navigate(`/news/${pathCat}${query}`, { replace: true });
     setDisplayCount(6);
-  }, [activeCategory, navigate, searchTerm]);
+  }, [activeCategory, navigate, searchTerm, categories.length]);
 
   const sortedCategories = useMemo(() => {
     const others = categories


### PR DESCRIPTION
Fixed an issue where the selected category was lost when navigating back from an article page.
Now, the user is returned to the same category (e.g., Community News, Developer News) with any search query preserved.

Fixes #424 