### PR TITLE
fix(TryCardData): correct typo 'ost' to 'most' in description

### DIFF
--- a/src/constants/TryCardData.ts
+++ b/src/constants/TryCardData.ts
@@ -75,7 +75,7 @@ export const TryCardData: CardDataType[] = [
   {
     title: 'Desktop/laptop installation',
     description:
-      'Sugar Learning platform can be installed as a full operating system on ost desktop and laptop computers.',
+      'Sugar Learning platform can be installed as a full operating system on most desktop and laptop computers.',
     tryNowText: 'Try Desktop Installation now!',
     tryNowHref: 'https://fedoraproject.org/spins/soas/download/',
     learnMoreText: 'Learn more about Installation',


### PR DESCRIPTION
## Changes Made
Fixed a typo in the Desktop/laptop installation card description.

## Details
- **File**: `src/constants/TryCardData.ts`
- **Line**: 78
- **Change**: "ost" → "most"

## Before
"Sugar Learning platform can be installed as a full operating system on ost desktop and laptop computers."

## After
"Sugar Learning platform can be installed as a full operating system on most desktop and laptop computers."

## Related Issue
Fixes #519 

## Checklist
- [x] Code follows project naming conventions
- [x] Change is minimal and focused
- [x] Commit message follows conventional commits format
- [x] No additional formatting or unrelated changes