### PR TITLE
Fix mobile dropdown visibility and improve responsive menu consistency

### DIFF
--- a/src/sections/Header.tsx
+++ b/src/sections/Header.tsx
@@ -18,6 +18,19 @@ const Header: React.FC = () => {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  // Handle window resize to close mobile menu on larger screens
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 1024) {
+        setIsMobileMenuOpen(false);
+        setActiveDropdown(null);
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   // Handle body scroll lock when mobile menu is open
   useEffect(() => {
     if (isMobileMenuOpen) {
@@ -160,7 +173,7 @@ const Header: React.FC = () => {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="fixed inset-0 bg-black/30 md:hidden z-40"
+            className="fixed inset-0 bg-black/30 lg:hidden z-40"
             onClick={() => setIsMobileMenuOpen(false)}
           />
         )}
@@ -195,8 +208,7 @@ const MobileNavDrawer: React.FC<{
           animate={{ opacity: 1, x: 0 }}
           exit={{ opacity: 0, x: '100%' }}
           transition={{ type: 'tween', duration: 0.3 }}
-          className="fixed md:hidden top-0 right-0 bottom-0 w-[80%] max-w-sm bg-white dark:bg-gray-900 shadow-xl z-40
-                    flex flex-col h-full"
+          className="fixed lg:hidden top-0 right-0 bottom-0 w-[80%] max-w-sm bg-white dark:bg-gray-900 shadow-xl z-40 flex flex-col h-full"
         >
           <div className="flex flex-col h-full">
             {/* Space to avoid overlay with main header */}


### PR DESCRIPTION
#499
resolves #531 


### **Description**
This PR resolves the issue where the mobile dropdown menu wasn’t appearing between 768px and 1023px due to incorrect breakpoint usage (md:hidden instead of lg:hidden). The menu is now properly visible for all widths below 1024px.

before

https://github.com/user-attachments/assets/20fa1dc2-e7a1-4fad-b849-25d388fdb760

after

https://github.com/user-attachments/assets/b79ae5a2-fdaa-44ce-93f5-83bfdb10d2c4



### **And also** 
While testing this fix, I also noticed an inconsistency where reopening the header after resizing caused the menu to stay open. I addressed this by adding a resize listener that automatically closes the mobile menu when the window width exceeds 1024px, ensuring consistent behavior across viewport changes.

before 

https://github.com/user-attachments/assets/15c0bb59-f7cf-4afe-8d4b-dccb0b59b371

after

https://github.com/user-attachments/assets/7ea36093-d348-4a9f-a656-588b9479302d

### **Changes done**

- Updated breakpoint classes from md:hidden → lg:hidden for the mobile overlay and drawer
- Added useEffect listener to reset isMobileMenuOpen and activeDropdown when window width ≥ 1024px