### PR TITLE
restored proper hover behavior

### DIFF
--- a/src/components/TryNow/LogoCard.tsx
+++ b/src/components/TryNow/LogoCard.tsx
@@ -18,7 +18,7 @@ const LogoCard = ({ logo, title, onClick, selected }: LogoCard) => {
       viewport={{ once: true, amount: 0.2 }}
       variants={logoCardAnimations.card}
       whileHover="hover"
-      animate={selected ? 'hover' : 'visible'}
+      animate="visible"
     >
       <motion.div
         className="w-24 h-24 bg-yellow-300 flex items-center justify-center rounded-full"


### PR DESCRIPTION
This pull request fixes a UI issue where the “using Raspbian” card on the Raspberry Pi page appeared enlarged by default.
Fixes : #586 
<img width="1200" height="988" alt="image" src="https://github.com/user-attachments/assets/3804ddd6-52b6-4168-a033-b6586905e994" />