### PR TITLE
Fixes Trymore3d component on medium screens

### DIFF
--- a/src/components/TryMore3D.tsx
+++ b/src/components/TryMore3D.tsx
@@ -107,7 +107,7 @@ export function TryMore() {
 
       {/* Marquee Section */}
       <div
-        className="flex flex-col lg:flex-row items-center gap-4 max-[1040px]:hidden"
+        className="flex flex-col lg:flex-row items-center gap-4 max-[1215px]:hidden"
         style={{
           transform:
             'translateX(0px) translateY(0px) translateZ(0px) rotateX(10deg) rotateY(-5deg) rotateZ(10deg)',


### PR DESCRIPTION
## 📝 Description

# Issue
The text in the TryMore3D section on the homepage is not fully visible because the marquee column section gets overlaps on screens between 1040px and 1210px wide.
<details>
<summary>Issue</summary>
<img width="1399" height="907" alt="image" src="https://github.com/user-attachments/assets/a963a524-ca3f-4ca5-88d8-6826aab57d10" />
</details>

# Solution
Currently, the marquee section is hidden up to 1040px width.
The solution is to extend this hidden range up to 1215px width, which will fix the issue.

* After the changes:
<details>
<summary>Below 1215px</summary>
<img width="1206" height="807" alt="below1215" src="https://github.com/user-attachments/assets/0286532d-0e87-49a8-b803-656357364dcc" />
</details>
<details>
<summary>Above 1215px</summary>
<img width="632" height="842" alt="above1215" src="https://github.com/user-attachments/assets/88c7b30a-d92e-4ec3-bed2-180894507c3d" />
</details>

* Alternative Solution:
Hide only 1–2 marquee columns on screens between 1040px and 1210px.

## 🔄 Type of Change

- [ ] 🎨 UI/UX Update (visual changes, styling improvements)
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement

### 🖥️ Responsive Design

<!--- Confirm testing on different screen sizes -->

- [ ] Desktop (1200px+)
- [ ] Tablet (768px - 1199px)
- [ ] Mobile (320px - 767px)
