### PR TITLE
Improve styling in scrolltotop button

### DIFF
--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -19,12 +19,14 @@ export default function ScrollToTop() {
       style={{ zIndex: 9999 }}
       className="
         fixed right-5 bottom-6
-        w-15 h-15 rounded-lg border-none
-        bg-emerald-300 text-black shadow-lg
+        w-12 h-12 sm:w-14 sm:h-14 rounded-lg
+        bg-emerald-500 text-white border-2 border-emerald-600
+        dark:bg-slate-800 dark:text-white dark:border-transparent
+        shadow-xl shadow-emerald-300/40 dark:shadow-black/30
         cursor-pointer flex items-center justify-center
-        opacity-95 hover:opacity-100 hover:-translate-y-[3px]
-        transition-transform duration-200 ease-in-out
-        focus:outline-none focus:ring-2 focus:ring-white/20 focus:ring-offset-2
+        opacity-100 hover:opacity-100 hover:-translate-y-[3px] hover:scale-105
+        transform transition-transform duration-200 ease-in-out
+        focus:outline-none focus:ring-2 focus:ring-emerald-300/60 dark:focus:ring-blue-300/30 focus:ring-offset-2
       "
     >
       <svg


### PR DESCRIPTION
## 📝 Description

# Issue 
* The ScrollToTop button currently uses the same style properties for both light and dark mode.

* The light mode appearance needs improvement for better visibility and design.

* The button has the same size on all screen sizes, and it needs responsive sizing.

<img width="102" height="110" alt="image" src="https://github.com/user-attachments/assets/e3fe189d-52ae-4412-91ac-b99fc229672e" />
<img width="104" height="108" alt="image" src="https://github.com/user-attachments/assets/3d752783-a4ff-4471-a858-3cd8b078c71b" />

# Solution 

* I added style properties for dark mode based on the website’s theme.

* I improved the styling in light mode for better visibility and added some effects.

* I also updated and added size properties for different screen sizes to improve responsiveness.

After the changes :-

<img width="99" height="101" alt="image" src="https://github.com/user-attachments/assets/431f396f-30af-4286-8c4e-2beaae400835" />
<img width="99" height="107" alt="image" src="https://github.com/user-attachments/assets/781677c1-22df-4c6b-8e4f-ba0aed5d75f2" />


## 🔄 Type of Change

- [ ] 🎨 UI/UX Update (visual changes, styling improvements)
- [ ] ⚡ Performance Improvement

## 🧪 Testing Performed

### 🖥️ Responsive Design

<!--- Confirm testing on different screen sizes -->

- [ ] Desktop (1200px+)
- [ ] Tablet (768px - 1199px)
- [ ] Mobile (320px - 767px)