### PR TITLE
fix(stats): fix stats hover style

### DIFF
--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { stats, statisticsData } from '@/constants/Stats.ts';
 import {
@@ -10,8 +9,6 @@ import {
 } from '@/styles/Animations';
 
 const Stats = () => {
-  const [activeCardIndex, setActiveCardIndex] = useState<number | null>(null);
-
   return (
     <section className="max-w-7xl mx-auto py-10 sm:py-16 md:py-20 px-4 sm:px-6 bg-white dark:bg-gray-900">
       <div className="relative mb-12 sm:mb-16 md:mb-24">
@@ -208,42 +205,47 @@ const Stats = () => {
 
         {/* Interactive Stats Summary - Grid Layout */}
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2 sm:gap-3 md:gap-4 max-w-6xl mx-auto px-2">
-          {statisticsData.map((stat, index) => {
-            const isActive = activeCardIndex === index;
-            const showFullText = isActive;
-
-            return (
-              <motion.div
-                key={index}
-                className={`px-2 sm:px-3 md:px-4 py-2 sm:py-3 rounded-md sm:rounded-lg ${stat.bgColor} border ${stat.borderColor} flex flex-col items-center justify-center relative group cursor-pointer`}
-                whileHover={{
+          {statisticsData.map((stat, index) => (
+            <motion.div
+              key={index}
+              className={`relative px-2 sm:px-3 md:px-4 py-2 sm:py-3 rounded-md sm:rounded-lg ${stat.bgColor} border ${stat.borderColor} flex flex-col items-center justify-center min-h-[90px]`}
+              whileHover="hover"
+              variants={{
+                hover: {
                   scale: 1.05,
-                  boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
-                }}
-                transition={{ type: 'spring', stiffness: 400, damping: 10 }}
-                onClick={() => setActiveCardIndex(isActive ? null : index)}
+                  transition: { type: 'spring', stiffness: 380, damping: 18 },
+                },
+              }}
+            >
+              <span
+                className={`font-bold text-transparent bg-clip-text bg-gradient-to-r ${stat.gradient} text-base sm:text-xl md:text-2xl`}
               >
-                <span
-                  className={`font-bold text-transparent bg-clip-text bg-gradient-to-r ${stat.gradient} text-base sm:text-xl md:text-2xl`}
-                >
-                  {stat.value}
-                </span>
-                {/* Truncated text - visible by default, hidden on hover (desktop) or when active (mobile) */}
-                <span
-                  className={`text-gray-700 dark:text-gray-300 text-2xs sm:text-xs md:text-sm text-center mt-0.5 sm:mt-1 line-clamp-1 ${showFullText ? 'hidden' : ''} lg:block lg:group-hover:hidden`}
-                >
-                  {stat.title.split('.')[0].substring(0, 12)}
-                  {stat.title.split('.')[0].length > 12 ? '...' : ''}
-                </span>
-                {/* Full text - visible on hover (desktop) or when active (mobile) */}
-                <span
-                  className={`text-gray-700 dark:text-gray-300 text-2xs sm:text-xs md:text-sm text-center mt-0.5 sm:mt-1 whitespace-normal px-1 ${showFullText ? 'block' : 'hidden'} lg:hidden lg:group-hover:block`}
-                >
-                  {stat.title}
-                </span>
+                {stat.value}
+              </span>
+
+              {/* Truncated display title */}
+              <span className="text-gray-700 dark:text-gray-300 text-2xs sm:text-xs md:text-sm text-center mt-1 line-clamp-1">
+                {stat.title}
+              </span>
+
+              {/* CENTERED FULL TITLE TOOLTIP (Hover Popup) */}
+              <motion.div
+                className="absolute left-1/2 bottom-[110%] -translate-x-1/2 px-3 py-2 rounded-md bg-gray-900 text-white text-xs sm:text-sm shadow-lg w-48 sm:w-64 text-center whitespace-normal break-words z-50 pointer-events-none"
+                initial={{ opacity: 0, scale: 0.8, y: 10 }}
+                variants={{
+                  hover: {
+                    opacity: 1,
+                    scale: 1,
+                    y: 0,
+                    transition: { duration: 0.25 },
+                  },
+                }}
+              >
+                {stat.title}
+                <div className="absolute left-1/2 top-full -translate-x-1/2 w-3 h-3 bg-gray-900 rotate-45"></div>
               </motion.div>
-            );
-          })}
+            </motion.div>
+          ))}
         </div>
       </motion.div>
     </section>


### PR DESCRIPTION
## Summary
This PR fixes the stats cards UI by adding a centered animated hover tooltip that displays the full stat title and removes hard truncation. It fixed the previous hover animations

Fixes #594 


## Before & After Comparison

### ❌ Before (Issue)


https://github.com/user-attachments/assets/57380591-f1f2-480d-be9f-38cf637be9f6




### ✔ After (Improved Behavior)

<img width="1589" height="432" alt="Screenshot 2025-11-28 201809" src="https://github.com/user-attachments/assets/f004979b-add8-44c3-9890-392573232ce3" />
<img width="1494" height="479" alt="Screenshot 2025-11-28 201800" src="https://github.com/user-attachments/assets/91e95f37-f4a9-4253-8c6a-69796606a85e" />
<img width="1792" height="463" alt="Screenshot 2025-11-28 201752" src="https://github.com/user-attachments/assets/802ad6f0-3b35-4fea-8134-4aedb3861996" />


## QA checklist (done before PR)
- [x] `npm run format` completed
- [x] `npm run lint:ts` passed
- [x] `npm run lint:md` passed
- [x] `npm run build` passed