### PR TITLE
Remove the duplicate backtotop button

### DIFF
--- a/src/pages/News/NewsDetailPage.tsx
+++ b/src/pages/News/NewsDetailPage.tsx
@@ -361,33 +361,6 @@ const NewsDetailPage: React.FC = () => {
             </div>
           </div>
         )}
-
-        {/* Back to Top Button */}
-        <div className="fixed bottom-8 right-8 z-50">
-          <motion.button
-            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-            className="p-3 bg-blue-600 text-white rounded-full shadow-lg hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400"
-            aria-label="Back to top"
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-6 w-6"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 15l7-7 7 7"
-              />
-            </svg>
-          </motion.button>
-        </div>
       </div>
 
       {/* Image Modal */}


### PR DESCRIPTION
## 📝 Description
 
## Issue
Duplicate Backtotop button on [Newsdetailpage](https://www.sugarlabs.org/news/all/fall-board-elections-2025-how-to-participate).

<details>
<summary>Issue</summary>
<img width="453" height="276" alt="image" src="https://github.com/user-attachments/assets/1d118e19-f9c4-462b-bba9-a5b219df9a77" />
</details>

## Solution
* I removed the custom BackToTop button from newsdetailpage.tsx.
* The default BackToTop button already works correctly on this page, so the extra one was not needed.

<details>
<summary>After The Changes</summary>
<img width="362" height="287" alt="image" src="https://github.com/user-attachments/assets/d75c73db-3c5b-403f-a28d-3d7b1f68ce55" />
</details>



## 🔄 Type of Change

- [ ] 🎨 UI/UX Update (visual changes, styling improvements)
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement


## 🧪 Testing Performed

### 📱 Browser Compatibility

### 🖥️ Responsive Design

<!--- Confirm testing on different screen sizes -->

- [ ] Desktop (1200px+)
- [ ] Tablet (768px - 1199px)
- [ ] Mobile (320px - 767px)