### PR TITLE
Fix text truncation in Activities Downloaded stat card

### DIFF
--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -135,7 +135,7 @@ const Stats = () => {
                   {stat.title}
                 </h3>
                 <motion.div
-                  className={`text-3xl sm:text-4xl md:text-5xl font-bold mt-2 mb-3 sm:mb-4 bg-gradient-to-r ${stat.gradient} bg-clip-text text-transparent font-Caveat break-words`}
+                  className={`text-2xl sm:text-3xl md:text-4xl font-bold mt-2 mb-3 sm:mb-4 bg-gradient-to-r ${stat.gradient} bg-clip-text text-transparent font-Caveat whitespace-nowrap`}
                   variants={numberCounter}
                 >
                   {stat.value}
@@ -175,7 +175,7 @@ const Stats = () => {
                   {stat.title}
                 </h3>
                 <motion.div
-                  className={`text-3xl sm:text-4xl md:text-5xl font-bold mt-2 mb-3 sm:mb-4 bg-gradient-to-r ${stat.gradient} bg-clip-text text-transparent font-Caveat break-words`}
+                  className={`text-2xl sm:text-3xl md:text-4xl font-bold mt-2 mb-3 sm:mb-4 bg-gradient-to-r ${stat.gradient} bg-clip-text text-transparent font-Caveat whitespace-nowrap`}
                   variants={numberCounter}
                 >
                   {stat.value}


### PR DESCRIPTION
## 🔗 Related Issue
 #602 [Bug]: Statistics card text truncation on homepage - "Activities Downloaded" number cut off


# Fix Text Truncation in Activities Downloaded Stat Card

## Description
Fixes the text truncation issue in the "Activities Downloaded" statistics card on the homepage where the number was being cut off, displaying "11,531,32" instead of the full "11,531,321+".

## Problem
The "Activities Downloaded" card in the "What numbers say for us?" section had a CSS overflow issue that truncated the last digit and the "+" symbol of the statistic value.

## Solution
Reduced the font size dynamically and added `whitespace-nowrap` to ensure the number stays on one line:
- Changed font size from `text-3xl sm:text-4xl md:text-5xl` to `text-2xl sm:text-3xl md:text-4xl`
- Replaced `break-words` with `whitespace-nowrap` to prevent line breaks
- Applied changes to both top and bottom row stat cards for consistency

This ensures:
- The complete value "11,531,321+" displays on a single line
- No text truncation or overflow
- Consistent sizing across all stat cards
- Responsive behavior maintained across all screen sizes

## Changes Made
- **File Modified:** `src/components/Stats.tsx`
- **Lines Changed:** 4 insertions, 4 deletions
- **Change:** Updated className for stat value display in both top and bottom row cards

## Screenshots
### Before
<img width="1079" height="1182" alt="Image" src="https://github.com/user-attachments/assets/254a9139-f723-4c3b-9d5c-988408dcedf7" />

### After
<img width="913" height="1196" alt="image" src="https://github.com/user-attachments/assets/b5ca86b6-af3a-4a76-98c0-7ca116fb8c3e" />

## Testing
- ✅ Build passes successfully (`npm run build`)
- ✅ Linting passes (`npm run lint`)
- ✅ Code formatted with Prettier (`npm run format`)

