### PR TITLE
fix: correct Matrix chat link Navigation

### DIFF
--- a/src/pages/Matrix.tsx
+++ b/src/pages/Matrix.tsx
@@ -295,7 +295,7 @@ const Matrix: React.FC = () => {
               </motion.p>
               <motion.a
                 href="https://matrix.to/#/#sugar-labs:matrix.org"
-                target='_blank'
+                target="_blank"
                 rel="noopener noreferrer"
                 className="bg-[#D4B062] hover:bg-white hover:text-black text-black font-medium px-6 sm:px-8 py-2.5 sm:py-3 rounded-full transition-all duration-300 shadow-lg hover:shadow-xl text-sm sm:text-base"
                 whileHover={{ scale: 1.05 }}

--- a/src/pages/Matrix.tsx
+++ b/src/pages/Matrix.tsx
@@ -295,6 +295,8 @@ const Matrix: React.FC = () => {
               </motion.p>
               <motion.a
                 href="https://matrix.to/#/#sugar-labs:matrix.org"
+                target='_blank'
+                rel="noopener noreferrer"
                 className="bg-[#D4B062] hover:bg-white hover:text-black text-black font-medium px-6 sm:px-8 py-2.5 sm:py-3 rounded-full transition-all duration-300 shadow-lg hover:shadow-xl text-sm sm:text-base"
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}

--- a/src/pages/Matrix.tsx
+++ b/src/pages/Matrix.tsx
@@ -294,7 +294,7 @@ const Matrix: React.FC = () => {
                 control.
               </motion.p>
               <motion.a
-                href="#get-started"
+                href="https://matrix.to/#/#sugar-labs:matrix.org"
                 className="bg-[#D4B062] hover:bg-white hover:text-black text-black font-medium px-6 sm:px-8 py-2.5 sm:py-3 rounded-full transition-all duration-300 shadow-lg hover:shadow-xl text-sm sm:text-base"
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}

--- a/src/pages/Matrix.tsx
+++ b/src/pages/Matrix.tsx
@@ -299,13 +299,13 @@ const Matrix: React.FC = () => {
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
                 onClick={(e) => {
-                  e.preventDefault()
-                  const element = document.getElementById('matrix-rooms')
-                  if(element) {
+                  e.preventDefault();
+                  const element = document.getElementById('matrix-rooms');
+                  if (element) {
                     element.scrollIntoView({
                       behavior: 'smooth',
-                      block: 'start'
-                    })
+                      block: 'start',
+                    });
                   }
                 }}
               >
@@ -360,7 +360,7 @@ const Matrix: React.FC = () => {
 
         {/* Matrix Rooms */}
         <motion.section
-          id='matrix-rooms'
+          id="matrix-rooms"
           initial="hidden"
           whileInView="visible"
           viewport={{ once: true, margin: '-100px' }}

--- a/src/pages/Matrix.tsx
+++ b/src/pages/Matrix.tsx
@@ -294,12 +294,20 @@ const Matrix: React.FC = () => {
                 control.
               </motion.p>
               <motion.a
-                href="https://matrix.to/#/#sugar-labs:matrix.org"
-                target="_blank"
-                rel="noopener noreferrer"
+                href="#matrix-rooms"
                 className="bg-[#D4B062] hover:bg-white hover:text-black text-black font-medium px-6 sm:px-8 py-2.5 sm:py-3 rounded-full transition-all duration-300 shadow-lg hover:shadow-xl text-sm sm:text-base"
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
+                onClick={(e) => {
+                  e.preventDefault()
+                  const element = document.getElementById('matrix-rooms')
+                  if(element) {
+                    element.scrollIntoView({
+                      behavior: 'smooth',
+                      block: 'start'
+                    })
+                  }
+                }}
               >
                 Get Started
               </motion.a>
@@ -352,6 +360,7 @@ const Matrix: React.FC = () => {
 
         {/* Matrix Rooms */}
         <motion.section
+          id='matrix-rooms'
           initial="hidden"
           whileInView="visible"
           viewport={{ once: true, margin: '-100px' }}


### PR DESCRIPTION
### Summary
Updated the Matrix chat link on the Contact Us page to correctly redirect users to the Sugar Labs Matrix Space instead of the landing page.

### Problem
When users attempted to join the Matrix chat via `/contact-us/matrix`, they were redirected to `/#get-started` (the landing page). This prevented community members and potential contributors from accessing the primary communication channel as this seems like a very potent way to join the chat room (although there are other ways too).

**Reproduction:**
1. Navigate to `https://www.sugarlabs.org/contact-us` (primary contact page)
2. Click the **Matrix chat** option (most visible community option)
2. Navigated to `https://www.sugarlabs.org/contact-us/matrix` by 
3. Click on the Matrix chat **Get Started** option
4. Observe the redirect to landing page instead of Matrix chat room

**Tested on:**
- Chrome (Desktop & Mobile)
- Brave (Desktop & Mobile)
- Firefox (Desktop)
- Safari (Mobile)

### Solution
- Replaced the broken navigation with a direct link to the official Sugar Labs Matrix Space using the universal link.
- Added `target="_blank"` and `rel="noopener noreferrer"` for proper external link handling

**Before - Getting redirected to landing page**
<img width="773" height="438" alt="image" src="https://github.com/user-attachments/assets/1207009d-395e-4daa-bb91-6ced5980c8de" />

**After - Getting redirected to the actual chat room**
<img width="827" height="437" alt="image" src="https://github.com/user-attachments/assets/c626b224-2a48-4d51-9785-3d25d9a156bc" />


**Note:** This is a straightforward fix that improves accessibility to the community's primary communication channel. No structural changes to routing or components were necessary beyond updating the link destination.