### PR TITLE
fix: Improved visibility of carousel indicator dots 

### DIFF
--- a/src/components/Product.tsx
+++ b/src/components/Product.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { products, ProductType } from '@/constants/ProductsData';
 import { Carousel } from 'react-responsive-carousel';
 import 'react-responsive-carousel/lib/styles/carousel.min.css';
+import '@/styles/Products.css';
 
 const Product = () => {
   return (

--- a/src/styles/Products.css
+++ b/src/styles/Products.css
@@ -1,0 +1,22 @@
+/* Carousel indicator dots - improved contrast */
+.carousel .control-dots .dot {
+  background-color: #9ca3af !important;
+  opacity: 0.7 !important;
+  box-shadow: none !important;
+}
+
+.carousel .control-dots .dot.selected {
+  background-color: #000000 !important;
+  opacity: 1 !important;
+}
+
+/* Dark mode support */
+.dark .carousel .control-dots .dot {
+  background-color: #6b7280 !important;
+  opacity: 0.7 !important;
+}
+
+.dark .carousel .control-dots .dot.selected {
+  background-color: #1f2937 !important;
+  opacity: 1 !important;
+}


### PR DESCRIPTION
## Description
   Improved visibility of carousel indicator dots on the products page by updating their colors for better contrast in both light and dark modes.

## Changes Made
   - Created `src/styles/Product.css` with custom dot styling - made a new file to keep things separate and clean
   - Inactive dots: Grey color for better visibility
   - Active dot: Black in light mode, dark grey in dark mode
   - Added proper dark mode support

## Fixes
   Implements the maintainer's suggestion from PR #652 "https://github.com/sugarlabs/www-v2/pull/652"

## Screenshots
### Before
**Light mode**
<img width="1339" height="634" alt="image" src="https://github.com/user-attachments/assets/41e6de40-51fa-4b44-a062-e3bc511ca376" />
**Dark mode**
<img width="1339" height="713" alt="image" src="https://github.com/user-attachments/assets/15e2053a-eb20-41e3-bd9e-a3ff81a54572" />
### After
**Light mode**
<img width="1370" height="633" alt="image" src="https://github.com/user-attachments/assets/9e1229fe-37b3-47ec-b26f-45922d757775" />
**Dark mode**
<img width="1369" height="654" alt="image" src="https://github.com/user-attachments/assets/2f10558f-1521-4d02-be3f-9b5aceafe05b" />

## Testing
   - Tested in light mode
   - Tested in dark mode
   - Dots are clearly visible in both modes
   - Active dot is easily distinguishable 