### PR TITLE
fix: remove deprecated baseUrl from tsconfig.app.json

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -23,7 +23,7 @@
     "noUncheckedSideEffectImports": true,
 
     /* Path Aliases */
-    "baseUrl": ".",
+
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
##Description

Removes the baseUrl option from tsconfig.app.json. This option is deprecated and will stop functioning in TypeScript 7.0.

Fixes #666

##Changes

Removed "baseUrl": "." from tsconfig.app.json.

##Verification

Verified that npm run build completes successfully (including type checking).

Verified that npm run lint passes without errors.