### PR TITLE
Fix dark mode toggle and contributors UI rendering issue. Fixes #677

### DIFF
--- a/src/pages/Contributors.tsx
+++ b/src/pages/Contributors.tsx
@@ -148,12 +148,18 @@ const Contributors: React.FC = () => {
     }
 
     if (error) {
-      return <div className="text-red-500 text-center py-10 dark:text-red-400">{error}</div>;
+      return (
+        <div className="text-red-500 text-center py-10 dark:text-red-400">
+          {error}
+        </div>
+      );
     }
 
     if (repos.length === 0) {
       return (
-        <p className="text-gray-500 text-center py-10 dark:text-gray-400">No repositories found</p>
+        <p className="text-gray-500 text-center py-10 dark:text-gray-400">
+          No repositories found
+        </p>
       );
     }
 
@@ -235,7 +241,11 @@ const Contributors: React.FC = () => {
     }
 
     if (error) {
-      return <div className="text-red-500 text-center py-10 dark:text-red-400">{error}</div>;
+      return (
+        <div className="text-red-500 text-center py-10 dark:text-red-400">
+          {error}
+        </div>
+      );
     }
 
     if (contributors.length === 0) {


### PR DESCRIPTION
## 📝 Description

This PR fixes two issues in the Sugar Labs Developers page:

1. **Dark Mode Fix:** Applied Tailwind dark mode classes to ensure proper dark mode styling across the page.  
2. **Contributors UI Fix (Local):** Commented out `variants={staggerContainer}` in the contributors list.  
   - The contributors list works on the live site ([https://www.sugarlabs.org/profiles/](https://www.sugarlabs.org/profiles/)) but was not displaying locally ([http://localhost:5173/profiles/](http://localhost:5173/profiles/)) due to `opacity: 0` in the staggered variants.

## 🔗 Related Issue

Fixes #677


**Video:**

- **Before Fix:**  

https://github.com/user-attachments/assets/0f65aeae-c171-4088-8056-1ef652372655

- **After Fix:**  
 

https://github.com/user-attachments/assets/02e7aea8-477b-4b6c-a13a-e271b25aa28f

