### PR TITLE
feat: Replace "Load More" button with Pagination System

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -48,12 +48,10 @@ const Pagination: React.FC<PaginationProps> = ({
       if (currentPage === 1) {
         const endAdjusted = Math.min(totalPages, 3);
         for (let i = 1; i <= endAdjusted; i++) pages.push(i);
-      }
-      else if (currentPage === totalPages) {
+      } else if (currentPage === totalPages) {
         const startAdjusted = Math.max(1, totalPages - 2);
         for (let i = startAdjusted; i <= totalPages; i++) pages.push(i);
-      }
-      else {
+      } else {
         for (let i = start; i <= end; i++) {
           pages.push(i);
         }

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -42,6 +42,10 @@ const Pagination: React.FC<PaginationProps> = ({
     const pages = [];
 
     if (isMobile) {
+      // Mobile Behavior:
+      // Due to limited screen width, we simplify the pagination.
+      // We only show the current page and its immediate neighbors (e.g., 4, 5, 6).
+      // Ellipses and first/last shortcuts are removed to prevent wrapping.
       const start = Math.max(1, currentPage - 1);
       const end = Math.min(totalPages, currentPage + 1);
 

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -26,9 +26,40 @@ const Pagination: React.FC<PaginationProps> = ({
   totalPages,
   onPageChange,
 }) => {
+  const [isMobile, setIsMobile] = React.useState(false);
+
+  React.useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 640);
+    };
+
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+    return () => window.removeEventListener('resize', checkMobile);
+  }, []);
+
   const getPageNumbers = () => {
     const pages = [];
-    // Always show first, last, current, and neighbors
+
+    if (isMobile) {
+      const start = Math.max(1, currentPage - 1);
+      const end = Math.min(totalPages, currentPage + 1);
+
+      if (currentPage === 1) {
+        const endAdjusted = Math.min(totalPages, 3);
+        for (let i = 1; i <= endAdjusted; i++) pages.push(i);
+      }
+      else if (currentPage === totalPages) {
+        const startAdjusted = Math.max(1, totalPages - 2);
+        for (let i = startAdjusted; i <= totalPages; i++) pages.push(i);
+      }
+      else {
+        for (let i = start; i <= end; i++) {
+          pages.push(i);
+        }
+      }
+      return pages;
+    }
 
     if (totalPages <= 7) {
       for (let i = 1; i <= totalPages; i++) {
@@ -36,22 +67,17 @@ const Pagination: React.FC<PaginationProps> = ({
       }
     } else {
       pages.push(1);
-
       if (currentPage > 3) {
         pages.push('...');
       }
-
       const start = Math.max(2, currentPage - 1);
       const end = Math.min(totalPages - 1, currentPage + 1);
-
       for (let i = start; i <= end; i++) {
         pages.push(i);
       }
-
       if (currentPage < totalPages - 2) {
         pages.push('...');
       }
-
       pages.push(totalPages);
     }
     return pages;
@@ -60,33 +86,35 @@ const Pagination: React.FC<PaginationProps> = ({
   if (totalPages <= 1) return null;
 
   return (
-    <div className="flex justify-center items-center gap-2 mt-12 mb-8">
+    <div className="flex flex-wrap justify-center items-center gap-1 sm:gap-2 mt-12 mb-8">
       <motion.button
         onClick={() => onPageChange(currentPage - 1)}
         disabled={currentPage === 1}
         whileHover={{ scale: 1.1 }}
         whileTap={{ scale: 0.9 }}
-        className={`p-3 rounded-xl flex items-center justify-center transition-all duration-300 ${
+        className={`p-2 sm:p-3 rounded-lg sm:rounded-xl flex items-center justify-center transition-all duration-300 ${
           currentPage === 1
             ? 'bg-gray-100 text-gray-400 cursor-not-allowed dark:bg-gray-800 dark:text-gray-600'
             : 'bg-gradient-to-br from-blue-500 to-green-500 text-white shadow-lg hover:shadow-xl'
         }`}
         aria-label="Previous Page"
       >
-        <ChevronLeft size={20} />
+        <ChevronLeft size={20} className="w-4 h-4 sm:w-5 sm:h-5" />
       </motion.button>
 
-      <div className="flex bg-white dark:bg-gray-800 rounded-2xl shadow-sm px-4 py-2 gap-2 items-center">
+      <div className="flex flex-wrap justify-center bg-white dark:bg-gray-800 rounded-xl sm:rounded-2xl shadow-sm px-2 sm:px-4 py-1 sm:py-2 gap-1 sm:gap-2 items-center">
         {getPageNumbers().map((page, index) => (
           <React.Fragment key={index}>
             {page === '...' ? (
-              <span className="text-gray-400 px-2">...</span>
+              <span className="text-gray-400 px-1 sm:px-2 text-xs sm:text-base">
+                ...
+              </span>
             ) : (
               <motion.button
                 onClick={() => onPageChange(page as number)}
                 whileHover={{ scale: 1.1 }}
                 whileTap={{ scale: 0.9 }}
-                className={`w-10 h-10 rounded-xl flex items-center justify-center text-sm font-bold transition-all duration-300 ${
+                className={`w-8 h-8 sm:w-10 sm:h-10 rounded-lg sm:rounded-xl flex items-center justify-center text-xs sm:text-sm font-bold transition-all duration-300 ${
                   currentPage === page
                     ? 'bg-gradient-to-br from-blue-600 to-green-600 text-white shadow-md transform -translate-y-1'
                     : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
@@ -104,14 +132,14 @@ const Pagination: React.FC<PaginationProps> = ({
         disabled={currentPage === totalPages}
         whileHover={{ scale: 1.1 }}
         whileTap={{ scale: 0.9 }}
-        className={`p-3 rounded-xl flex items-center justify-center transition-all duration-300 ${
+        className={`p-2 sm:p-3 rounded-lg sm:rounded-xl flex items-center justify-center transition-all duration-300 ${
           currentPage === totalPages
             ? 'bg-gray-100 text-gray-400 cursor-not-allowed dark:bg-gray-800 dark:text-gray-600'
             : 'bg-gradient-to-br from-blue-500 to-green-500 text-white shadow-lg hover:shadow-xl'
         }`}
         aria-label="Next Page"
       >
-        <ChevronRight size={20} />
+        <ChevronRight size={20} className="w-4 h-4 sm:w-5 sm:h-5" />
       </motion.button>
     </div>
   );

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+/**
+ * Props for the Pagination component.
+ */
+interface PaginationProps {
+  /** The current active page number (1-based index). */
+  currentPage: number;
+  /** The total number of pages available. */
+  totalPages: number;
+  /** Callback function invoked when a page number is clicked. */
+  onPageChange: (page: number) => void;
+}
+
+/**
+ * A reusable Pagination component that renders previous/next buttons and page numbers.
+ * Supports smart ellipses for large page counts.
+ *
+ * @param props - The props for the component.
+ * @returns A JSX element representing the pagination controls.
+ */
+const Pagination: React.FC<PaginationProps> = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+}) => {
+  const getPageNumbers = () => {
+    const pages = [];
+    // Always show first, last, current, and neighbors
+
+    if (totalPages <= 7) {
+      for (let i = 1; i <= totalPages; i++) {
+        pages.push(i);
+      }
+    } else {
+      pages.push(1);
+
+      if (currentPage > 3) {
+        pages.push('...');
+      }
+
+      const start = Math.max(2, currentPage - 1);
+      const end = Math.min(totalPages - 1, currentPage + 1);
+
+      for (let i = start; i <= end; i++) {
+        pages.push(i);
+      }
+
+      if (currentPage < totalPages - 2) {
+        pages.push('...');
+      }
+
+      pages.push(totalPages);
+    }
+    return pages;
+  };
+
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex justify-center items-center gap-2 mt-12 mb-8">
+      <motion.button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+        whileHover={{ scale: 1.1 }}
+        whileTap={{ scale: 0.9 }}
+        className={`p-3 rounded-xl flex items-center justify-center transition-all duration-300 ${
+          currentPage === 1
+            ? 'bg-gray-100 text-gray-400 cursor-not-allowed dark:bg-gray-800 dark:text-gray-600'
+            : 'bg-gradient-to-br from-blue-500 to-green-500 text-white shadow-lg hover:shadow-xl'
+        }`}
+        aria-label="Previous Page"
+      >
+        <ChevronLeft size={20} />
+      </motion.button>
+
+      <div className="flex bg-white dark:bg-gray-800 rounded-2xl shadow-sm px-4 py-2 gap-2 items-center">
+        {getPageNumbers().map((page, index) => (
+          <React.Fragment key={index}>
+            {page === '...' ? (
+              <span className="text-gray-400 px-2">...</span>
+            ) : (
+              <motion.button
+                onClick={() => onPageChange(page as number)}
+                whileHover={{ scale: 1.1 }}
+                whileTap={{ scale: 0.9 }}
+                className={`w-10 h-10 rounded-xl flex items-center justify-center text-sm font-bold transition-all duration-300 ${
+                  currentPage === page
+                    ? 'bg-gradient-to-br from-blue-600 to-green-600 text-white shadow-md transform -translate-y-1'
+                    : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
+                }`}
+              >
+                {page}
+              </motion.button>
+            )}
+          </React.Fragment>
+        ))}
+      </div>
+
+      <motion.button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+        whileHover={{ scale: 1.1 }}
+        whileTap={{ scale: 0.9 }}
+        className={`p-3 rounded-xl flex items-center justify-center transition-all duration-300 ${
+          currentPage === totalPages
+            ? 'bg-gray-100 text-gray-400 cursor-not-allowed dark:bg-gray-800 dark:text-gray-600'
+            : 'bg-gradient-to-br from-blue-500 to-green-500 text-white shadow-lg hover:shadow-xl'
+        }`}
+        aria-label="Next Page"
+      >
+        <ChevronRight size={20} />
+      </motion.button>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/src/pages/News/AuthorPage.tsx
+++ b/src/pages/News/AuthorPage.tsx
@@ -10,8 +10,8 @@ import {
   Grid,
   List,
   Search,
-  ChevronDown,
 } from 'lucide-react';
+import Pagination from '@/components/Pagination';
 
 import Header from '@/sections/Header';
 import Footer from '@/sections/Footer';
@@ -30,7 +30,8 @@ const AuthorPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   // UI State
-  const [displayCount, setDisplayCount] = useState(6);
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 6;
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('All');
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
@@ -98,7 +99,7 @@ const AuthorPage: React.FC = () => {
     });
 
     setFilteredPosts(filtered);
-    setDisplayCount(6); // Reset display count when filters change
+    setCurrentPage(1); // Reset page when filters change
   }, [posts, searchTerm, selectedCategory, sortBy]);
 
   const handlePostClick = (post: PostMetaData) => {
@@ -106,8 +107,9 @@ const AuthorPage: React.FC = () => {
     navigate(`/news/${categoryPath}/${post.slug}`);
   };
 
-  const handleShowMore = () => {
-    setDisplayCount((prev) => Math.min(prev + 6, filteredPosts.length));
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const getUniqueCategories = () => {
@@ -115,8 +117,11 @@ const AuthorPage: React.FC = () => {
     return ['All', ...categories.sort()];
   };
 
-  const visiblePosts = filteredPosts.slice(0, displayCount);
-  const hasMore = filteredPosts.length > displayCount;
+  const totalPages = Math.ceil(filteredPosts.length / itemsPerPage);
+  const visiblePosts = filteredPosts.slice(
+    (currentPage - 1) * itemsPerPage,
+    currentPage * itemsPerPage,
+  );
 
   if (isLoading) {
     return (
@@ -435,24 +440,11 @@ const AuthorPage: React.FC = () => {
                       </AnimatePresence>
                     </motion.div>
 
-                    {/* Load More Button */}
-                    {hasMore && (
-                      <div className="text-center mt-8">
-                        <motion.button
-                          onClick={handleShowMore}
-                          className="px-6 py-3 bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800 text-white 
-                          rounded-lg transition-colors font-medium flex items-center gap-2 mx-auto shadow-md dark:shadow-blue-500/20"
-                          whileHover={{ scale: 1.05 }}
-                          whileTap={{ scale: 0.95 }}
-                        >
-                          Load More Articles
-                          <ChevronDown className="w-4 h-4" />
-                          <span className="text-xs bg-blue-500 dark:bg-blue-600 px-2 py-1 rounded-full">
-                            +{Math.min(6, filteredPosts.length - displayCount)}
-                          </span>
-                        </motion.button>
-                      </div>
-                    )}
+                    <Pagination
+                      currentPage={currentPage}
+                      totalPages={totalPages}
+                      onPageChange={handlePageChange}
+                    />
                   </>
                 )}
               </div>

--- a/src/pages/News/NewsPage.tsx
+++ b/src/pages/News/NewsPage.tsx
@@ -9,14 +9,8 @@ import {
 import Header from '@/sections/Header';
 import Footer from '@/sections/Footer';
 import { motion } from 'framer-motion';
+import { fadeIn, slideInBottom, floatUpAndFade } from '@/styles/Animations';
 import {
-  fadeIn,
-  slideInBottom,
-  bounce,
-  floatUpAndFade,
-} from '@/styles/Animations';
-import {
-  ArrowRight,
   Grid3X3,
   List,
   Search,
@@ -27,6 +21,7 @@ import {
   X,
 } from 'lucide-react';
 import PostCard from '@/components/PostCard';
+import Pagination from '@/components/Pagination';
 
 const NewsPage: React.FC = () => {
   const [shareModalOpen, setShareModalOpen] = useState(false);
@@ -39,7 +34,8 @@ const NewsPage: React.FC = () => {
   >({});
   const [categories, setCategories] = useState<string[]>([]);
   const [activeCategory, setActiveCategory] = useState<string>('All');
-  const [displayCount, setDisplayCount] = useState<number>(6);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const itemsPerPage = 9;
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<'grid' | 'list' | 'magazine'>(
@@ -80,6 +76,7 @@ const NewsPage: React.FC = () => {
       }
     }
     setActiveCategory('All');
+    setCurrentPage(1);
   }, [categoryParam, categories]);
 
   // Keep searchTerm in sync with the URL (?q=)
@@ -87,6 +84,7 @@ const NewsPage: React.FC = () => {
     const params = new URLSearchParams(location.search);
     const q = params.get('q') || '';
     setSearchTerm(q);
+    setCurrentPage(1);
   }, [location.search]);
 
   const sortedCategories = useMemo(() => {
@@ -112,19 +110,21 @@ const NewsPage: React.FC = () => {
     return posts;
   }, [postsByCategory, activeCategory, searchTerm]);
 
-  const visiblePosts = useMemo(() => {
-    return filteredPosts.slice(0, displayCount);
-  }, [filteredPosts, displayCount]);
+  const totalPages = Math.ceil(filteredPosts.length / itemsPerPage);
 
-  const hasMore = filteredPosts.length > displayCount;
+  const visiblePosts = useMemo(() => {
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    return filteredPosts.slice(startIndex, startIndex + itemsPerPage);
+  }, [filteredPosts, currentPage]);
 
   const handleCategoryClick = (cat: string) => {
     setActiveCategory(cat);
+    setCurrentPage(1);
   };
 
-  const handleShowMore = () => {
-    const total = filteredPosts.length;
-    setDisplayCount((prev) => Math.min(prev + 6, total));
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const handlePostClick = (slug: string) => {
@@ -461,34 +461,11 @@ const NewsPage: React.FC = () => {
               </div>
             </div>
 
-            {/* Enhanced Load More Button */}
-            {hasMore && (
-              <div className="flex justify-center">
-                <motion.button
-                  onClick={handleShowMore}
-                  className="relative px-8 py-4 bg-linear-to-r from-blue-600 to-green-600 text-white hover:from-blue-700 hover:to-green-700 cursor-pointer transition-all duration-300 rounded-2xl shadow-lg hover:shadow-2xl font-medium flex items-center gap-3 group"
-                  variants={bounce}
-                  initial="hidden"
-                  animate="visible"
-                  whileHover="hover"
-                  whileTap="tap"
-                >
-                  <div className="relative group rounded-xl overflow-hidden">
-                    <div className="absolute inset-0 bg-white opacity-0 group-hover:opacity-10 transition-opacity duration-300 rounded-xl"></div>
-                  </div>
-                  <span className="relative z-10">Load More Articles</span>
-                  <ArrowRight
-                    size={18}
-                    className="relative z-10 group-hover:translate-x-1 transition-transform duration-300"
-                  />
-                  <div className="absolute -top-1 -right-1 w-6 h-6 bg-yellow-400 rounded-full flex items-center justify-center">
-                    <span className="text-xs font-bold text-gray-800">
-                      {Math.min(6, filteredPosts.length - displayCount)}
-                    </span>
-                  </div>
-                </motion.button>
-              </div>
-            )}
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={handlePageChange}
+            />
           </div>
         </section>
       </main>

--- a/src/pages/News/TagPage.tsx
+++ b/src/pages/News/TagPage.tsx
@@ -10,10 +10,10 @@ import {
   Grid,
   List,
   Filter,
-  ChevronDown,
   BookOpen,
   TrendingUp,
 } from 'lucide-react';
+import Pagination from '@/components/Pagination';
 
 import Header from '@/sections/Header';
 import Footer from '@/sections/Footer';
@@ -30,7 +30,8 @@ const TagPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   // UI State
-  const [displayCount, setDisplayCount] = useState(8);
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 8;
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('All');
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
@@ -102,7 +103,7 @@ const TagPage: React.FC = () => {
     });
 
     setFilteredPosts(filtered);
-    setDisplayCount(8);
+    setCurrentPage(1);
   }, [posts, searchTerm, selectedCategory, sortBy, tag]);
 
   const handlePostClick = (post: PostMetaData) => {
@@ -116,8 +117,9 @@ const TagPage: React.FC = () => {
     }
   };
 
-  const handleShowMore = () => {
-    setDisplayCount((prev) => Math.min(prev + 8, filteredPosts.length));
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const getUniqueCategories = () => {
@@ -141,8 +143,11 @@ const TagPage: React.FC = () => {
       .map(([tagName]) => tagName);
   };
 
-  const visiblePosts = filteredPosts.slice(0, displayCount);
-  const hasMore = filteredPosts.length > displayCount;
+  const totalPages = Math.ceil(filteredPosts.length / itemsPerPage);
+  const visiblePosts = filteredPosts.slice(
+    (currentPage - 1) * itemsPerPage,
+    currentPage * itemsPerPage,
+  );
   const relatedTags = getRelatedTags();
 
   if (isLoading) {
@@ -486,23 +491,11 @@ const TagPage: React.FC = () => {
                     </AnimatePresence>
                   </motion.div>
 
-                  {/* Load More Button */}
-                  {hasMore && (
-                    <div className="text-center">
-                      <motion.button
-                        onClick={handleShowMore}
-                        className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium flex items-center gap-2 mx-auto"
-                        whileHover={{ scale: 1.05 }}
-                        whileTap={{ scale: 0.95 }}
-                      >
-                        Load More Articles
-                        <ChevronDown className="w-4 h-4" />
-                        <span className="text-xs bg-blue-500 px-2 py-1 rounded-full">
-                          +{Math.min(8, filteredPosts.length - displayCount)}
-                        </span>
-                      </motion.button>
-                    </div>
-                  )}
+                  <Pagination
+                    currentPage={currentPage}
+                    totalPages={totalPages}
+                    onPageChange={handlePageChange}
+                  />
                 </>
               )}
             </div>


### PR DESCRIPTION
## 📝 Description
Refactored the post navigation system in the News, Author, and Tag pages to significantly improve user experience and performance.

Previously, these pages utilized a "Load More" button which simply appended more items to the current list. This approach could lead to performance issues with large datasets and made it difficult for users to navigate to specific sections of the news feed.

### This PR introduces the following changes:

1. New Component: Created a reusable, responsive Pagination component (src/components/Pagination.tsx) featuring:
Previous/Next navigation buttons. Smart page numbering with ellipses for large page counts. Active page highlighting with gradient styling. Smooth hover and click animations using framer-motion.

1. News Page Refactor: Completely replaced the "Load More" logic in  NewsPage.tsx with a page-based system. Implemented currentPage state management. Added auto-scroll to top on page change for better UX. Ensured filters (Search, Category) automatically reset the view to Page 1. 

1. Author & Tag Page Refactor: Applied the same pagination logic to AuthorPage.tsx and TagPage.tsx for a consistent experience across the site.

1. Cleanup: Removed unused imports and icons associated with the legacy "Load More" button.


## 🔗 Related Issue

<!--- If this PR is related to any issue(s), link them here using #issue_number -->
<!--- For example: "Fixes #123" or "Part of #456" -->

Fixes #672 

## 🔄 Type of Change

<!--- What types of changes does your code introduce? Put an x in all boxes that apply: -->

- [x] 📱 New Feature (new page, component, or functionality)
- [x] 🎨 UI/UX Update (visual changes, styling improvements)
- [x] ⚡ Performance Improvement
- [x] 🧹 Code Refactoring

## 📷 Visual Changes

<!--- If your changes affect the website's appearance, please provide screenshots -->
<!--- For UI changes, include before/after screenshots if possible -->
### BEFORE
https://github.com/user-attachments/assets/cd85e2ed-8ac3-4827-b5ae-b7a94f525839

<img width="511" height="155" alt="Screenshot 2025-12-26 180719" src="https://github.com/user-attachments/assets/75b4ec09-2046-4d97-8fc2-335943806dc5" />


### AFTER
https://github.com/user-attachments/assets/cf7431f8-1ed6-42f8-abb2-e7a0dfec945c

<img width="538" height="197" alt="Screenshot 2025-12-26 180658" src="https://github.com/user-attachments/assets/dc514996-fbd1-49c1-bf12-2b084fd9f4e2" />

