### PR TITLE
Fix dropdown text visibility in dark mode

### DIFF
--- a/src/pages/News/TagPage.tsx
+++ b/src/pages/News/TagPage.tsx
@@ -279,7 +279,7 @@ const TagPage: React.FC = () => {
                       <select
                         value={selectedCategory}
                         onChange={(e) => setSelectedCategory(e.target.value)}
-                        className="px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                        className="px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm dark:bg-gray-800"
                       >
                         {getUniqueCategories().map((category) => (
                           <option key={category} value={category}>
@@ -296,7 +296,7 @@ const TagPage: React.FC = () => {
                             e.target.value as 'date' | 'title' | 'relevance',
                           )
                         }
-                        className="px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                        className="px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm dark:bg-gray-800"
                       >
                         <option value="date">Latest First</option>
                         <option value="title">A-Z</option>


### PR DESCRIPTION
---
name: Pull Request
about: Submit changes to the Sugar Labs website for review
---

## 📝 Description

On the Tag page, the select dropdowns have unreadable text in dark mode due to missing dark background styles.

## 🔗 Related Issue

Fixes #690 

## 🔄 Type of Change

<!--- What types of changes does your code introduce? Put an `x` in all boxes that apply: -->

- [ ] 📱 New Feature (new page, component, or functionality)
- [x] 🎨 UI/UX Update (visual changes, styling improvements)
- [ ] 📖 Content Update (text changes, documentation)
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [ ] ♿ Accessibility Enhancement
- [ ] 🔒 Security Update
- [ ] 📦 Dependency Update
- [ ] 🧹 Code Refactoring
- [ ] 🧪 Test Updates

## Visual Changes
## Before

https://github.com/user-attachments/assets/b918c92f-10f6-4392-9619-fdcbf29d2f93

## After

https://github.com/user-attachments/assets/28cf85f2-bb88-49b2-b77b-d9dfbf6ef807

### Notes
No functional or layout changes.
