### PR TITLE
fix: [UI] enhanced the visibility of components in light mode matchin

### DIFF
--- a/src/pages/Contributors.tsx
+++ b/src/pages/Contributors.tsx
@@ -181,8 +181,8 @@ const Contributors: React.FC = () => {
               onClick={() => handleRepoClick(repo.name)}
               className={`p-4 rounded-lg cursor-pointer transition duration-300 border-l-4 ${
                 selectedRepo === repo.name
-                  ? 'bg-[#D4B062]/10 border-[#D4B062] dark:bg-[#D4B062]/20'
-                  : 'hover:bg-gray-50 border-transparent hover:border-gray-200 dark:hover:bg-gray-800 dark:hover:border-gray-700'
+                  ? 'bg-[#FFF4E6] border-[#D4B062] dark:bg-[#D4B062]/20'
+                  : 'hover:bg-gray-100 border-transparent hover:border-gray-200 dark:hover:bg-gray-800 dark:hover:border-gray-700'
               }`}
             >
               <h3 className="font-medium text-lg text-gray-800 break-words dark:text-gray-100">
@@ -276,7 +276,7 @@ const Contributors: React.FC = () => {
                 href={contributor.html_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group flex flex-col items-center p-5 bg-gray-50 rounded-lg transition duration-300 hover:bg-[#D4B062]/5 hover:shadow-md border border-gray-100 dark:bg-gray-800 dark:hover:bg-[#D4B062]/10 dark:border-gray-700"
+                className="group flex flex-col items-center p-5 bg-gray-100 rounded-lg transition duration-300 hover:bg-[#FFF4E6] border border-gray-100 dark:bg-gray-800 dark:hover:bg-[#D4B062]/10 dark:border-gray-700"
               >
                 <div className="relative mb-3">
                   <img


### PR DESCRIPTION
---
Name: Pull Request
About: Submit changes to the Sugar Labs website for review
---

## Description
While going through the `/profiles` route, I saw that the dark mode looked very beautiful with exceptional colour contrast, but the same lacked in light mode. It was not very perfectly visible, so I just worked through those drawbacks and made them look warmer and more visible. Also, it matches all the style patterns followed in dark mode, but with compatible colours and contrast.

## Type of Change
Just some UI based changes.

## 📷 Visual Changes

### 1. For selected repo from the repo list and for hover over them - 

**Before** - It looked lighter when hovered and when selected too

<img width="663" height="523" alt="image" src="https://github.com/user-attachments/assets/af6e38a1-a936-4ca6-8d1a-9300381e13a0" />

**After** - It is more visible and matches the card colours of contributors too.

<img width="667" height="517" alt="image" src="https://github.com/user-attachments/assets/7a39ecde-a45d-4790-ad7a-1a6d65207d54" />

### 2. For the contributor cards - 

**Before** - the hover was slightly less visible & the card colours were merging with background

<img width="935" height="449" alt="image" src="https://github.com/user-attachments/assets/b25bc67c-f7f8-4e9f-9571-e30a2a6412bb" />

**After** - the hover is a little more visible & the cards are more visible even when idle

<img width="940" height="467" alt="image" src="https://github.com/user-attachments/assets/bae7ae08-b550-40bc-977e-b014af3cc72e" />

**These things are already perfect in dark mode, so I did not post those pictures here**

### I made the colours of "List of repositories" & "List of contributors" match each other so they look consistent too.

Thanks. Feel free to suggest any changes.