### PR TITLE
fix(volunteer): restrict YouTube embed recommendations to Sugar Lab

### DIFF
--- a/src/pages/Volunteer.tsx
+++ b/src/pages/Volunteer.tsx
@@ -197,7 +197,7 @@ const Volunteer = () => {
             <div className="w-full max-w-3xl aspect-video">
               <iframe
                 className="w-full h-full rounded-lg"
-                src="https://www.youtube.com/embed/W5ZLFBZkE34"
+                src="https://www.youtube.com/embed/W5ZLFBZkE34?rel=0"
                 title="YouTube Video"
                 frameBorder="0"
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
# Fixes #702 

## Summary
This PR improves the embedded YouTube video behavior on the **Volunteer** page to ensure a more professional and distraction-free user experience. It prevents unrelated, user-history–based video recommendations from appearing when the video is paused or completed, keeping post-playback suggestions relevant to Sugar Labs.

---

## Issue

- The embedded YouTube video displays recommendations based on the viewer’s personal YouTube watch history.
- Suggested content may include unrelated videos such as music, movie trailers, or other non-mission-aligned media.
- This behavior detracts from the professional tone of the Sugar Labs website and may distract volunteers.

---

## Root Cause

The video is embedded using a standard YouTube `<iframe>` with default behavior, which allows YouTube to surface recommendations driven by the user’s personal viewing history rather than channel-specific or contextual content.

---

## Changes Made

- Updated the YouTube embed configuration on the Volunteer page.
- Ensured recommendations are aligned with Sugar Labs content rather than user-specific watch history.
- Kept existing layout, styling, and video playback behavior unchanged.

---

## Expected Result

- The video plays normally without any change to UX or layout.
- When the video is paused or finishes playing:
  - Recommendations remain relevant to Sugar Labs.
  - Unrelated or distracting content is no longer displayed.
- The Volunteer page maintains a professional, mission-focused presentation.

---

## Environment Tested

- **OS:** Windows, macOS  
- **Browsers:** Chrome, Firefox, Edge  
- **Device:** Desktop & Mobile  

---

## Before

- Pausing or completing the video shows unrelated YouTube recommendations influenced by personal watch history.
<img width="1919" height="904" alt="image" src="https://github.com/user-attachments/assets/81a6665f-f393-49fc-b448-5b0e4090087c" />

<img width="1919" height="971" alt="image" src="https://github.com/user-attachments/assets/488cc5f2-fbb8-4cee-964a-0fa5737b05c8" />


## After

- Pausing or completing the video shows only contextually relevant recommendations aligned with Sugar Labs content.

<img width="1600" height="810" alt="image" src="https://github.com/user-attachments/assets/e422381e-e3bd-4075-9a86-d075aa2bdb71" />


_This change is intentionally minimal and scoped strictly to the YouTube embed behavior on the Volunteer page to avoid any unintended side effects. I’m happy to make adjustments based on reviewer feedback._