### PR TITLE
fix(ui): standardize “Join us and make a difference” section using a Bento-style grid layout

### DIFF
--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -204,9 +204,7 @@ const Stats = () => {
         </p>
 
         {/* Interactive Stats Summary - Grid Layout */}
-        <div
-          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-7xl mx-auto px-4 w-full"
-        >
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-7xl mx-auto px-4 w-full">
           {statisticsData.map((stat, index) => (
             <div
               key={index}


### PR DESCRIPTION
# Fixes #718 

## Summary

This PR refactors the **“Join us and make a difference”** section on the homepage to use a clean, standardized **grid-based (Bento-style) layout**.

The previous interactive/expandable card behavior caused layout instability and visual inconsistencies. To improve UI consistency, readability, and maintainability, the section has been simplified to display key statistics in a static, well-aligned grid.

---

## What Changed

- Replaced the expandable / interactive card layout with a **standard CSS Grid (3-column) layout**
- Ensured cards consistently fill the available container width with no unused space
- Removed complex expansion and alignment logic to maintain a stable layout
- Simplified card content to a clear **Number + Description** format
- Eliminated unused React state and event listeners
- Retained subtle hover feedback for better user experience

---

## Why This Change

- Improves **visual stability** and avoids unintended layout shifts
- Aligns with **industry-standard “Bento Grid” design patterns**
- Enhances **readability and accessibility**
- Reduces code complexity and improves maintainability
- Ensures consistent behavior across screen sizes

---

## Video reference

<video src="https://github.com/user-attachments/assets/bd7734ff-ba72-47e6-8df3-366e166cf182" controls width="500"></video>