### PR TITLE
fix(Stats): remove duplicate statistics section

### DIFF
--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { stats, statisticsData } from '@/constants/Stats.ts';
 import {
@@ -10,8 +9,6 @@ import {
 } from '@/styles/Animations';
 
 const Stats = () => {
-  const [activeCardIndex, setActiveCardIndex] = useState<number | null>(null);
-
   return (
     <section className="max-w-7xl mx-auto py-10 sm:py-16 md:py-20 px-4 sm:px-6 bg-white dark:bg-gray-900">
       <div className="relative mb-12 sm:mb-16 md:mb-24">
@@ -186,64 +183,6 @@ const Stats = () => {
               </div>
             </motion.div>
           ))}
-        </div>
-      </motion.div>
-
-      {/* Closing Section with Interactive Element */}
-      <motion.div
-        className="text-center mt-10 sm:mt-12 md:mt-16 pt-8 sm:pt-12 md:pt-16 border-t border-gray-200 dark:border-gray-700"
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.8 }}
-        viewport={{ once: true }}
-      >
-        <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-gray-800 dark:text-white mb-4 sm:mb-6">
-          Join us and make a difference
-        </h2>
-        <p className="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto mb-6 sm:mb-8 md:mb-10 px-4 text-sm sm:text-base md:text-lg">
-          These numbers represent more than statistics - they represent lives
-          changed through education and technology. Sugar Labs continues to grow
-          and impact communities worldwide.
-        </p>
-
-        {/* Interactive Stats Summary - Grid Layout */}
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2 sm:gap-3 md:gap-4 max-w-6xl mx-auto px-2">
-          {statisticsData.map((stat, index) => {
-            const isActive = activeCardIndex === index;
-            const showFullText = isActive;
-
-            return (
-              <motion.div
-                key={index}
-                className={`px-2 sm:px-3 md:px-4 py-2 sm:py-3 rounded-md sm:rounded-lg ${stat.bgColor} border ${stat.borderColor} flex flex-col items-center justify-center relative group cursor-pointer`}
-                whileHover={{
-                  scale: 1.05,
-                  boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
-                }}
-                transition={{ type: 'spring', stiffness: 400, damping: 10 }}
-                onClick={() => setActiveCardIndex(isActive ? null : index)}
-              >
-                <span
-                  className={`font-bold text-transparent bg-clip-text bg-gradient-to-r ${stat.gradient} text-base sm:text-xl md:text-2xl`}
-                >
-                  {stat.value}
-                </span>
-                {/* Truncated text - visible by default, hidden on hover (desktop) or when active (mobile) */}
-                <span
-                  className={`text-gray-700 dark:text-gray-300 text-2xs sm:text-xs md:text-sm text-center mt-0.5 sm:mt-1 line-clamp-1 ${showFullText ? 'hidden' : ''} lg:block lg:group-hover:hidden`}
-                >
-                  {stat.title.split('.')[0].substring(0, 12)}
-                  {stat.title.split('.')[0].length > 12 ? '...' : ''}
-                </span>
-                {/* Full text - visible on hover (desktop) or when active (mobile) */}
-                <span
-                  className={`text-gray-700 dark:text-gray-300 text-2xs sm:text-xs md:text-sm text-center mt-0.5 sm:mt-1 whitespace-normal px-1 ${showFullText ? 'block' : 'hidden'} lg:hidden lg:group-hover:block`}
-                >
-                  {stat.title}
-                </span>
-              </motion.div>
-            );
-          })}
         </div>
       </motion.div>
     </section>


### PR DESCRIPTION
## 📝 Description

Removed the duplicate statistics section that was appearing in the "Join us and make a difference" closing area of the homepage. The statistics numbers (3,000,000+, 344+, 1,450+, 11,531,321+, 170, 55+) were being rendered twice on the page - once in the main stats grid and again in the closing section, causing unnecessary content duplication and a cluttered page layout.

## 🔗 Related Issue

Fixes #747 

## 🔄 Type of Change

- Bug Fix
- Performance Improvement
- Content Cleanup

## 🧪 Testing Performed

**Browser Compatibility:**
- Chrome (Latest) ✅
- Firefox (Latest) ✅
- Safari (Latest) ✅
- Edge (Latest) ✅

**Responsive Design:**
- Desktop (1200px+) ✅
- Tablet (768px - 1199px) ✅
- Mobile (320px - 767px) ✅

**Test Cases:**
1. Verified stats display only once on the page
2. Confirmed no console errors or warnings
3. Verified all animations and styling still work correctly

## Screenshot
<img width="1137" height="595" alt="Screenshot 2026-01-10 at 10 34 56 PM" src="https://github.com/user-attachments/assets/3d7e3383-6d1f-4679-97e6-ef843480a4d1" />
<img width="1196" height="668" alt="Screenshot 2026-01-10 at 10 49 51 PM" src="https://github.com/user-attachments/assets/7d4c333f-f86f-4e28-a421-148458bbcb97" />

## 📋 PR Checklist

- Code follows project's coding style guidelines ✅
- Tested changes locally ✅
- No new warnings or console errors ✅
- All existing tests pass ✅

## 💭 Additional Notes

- Removed the unused `useState` and `activeCardIndex` state variable since the interactive grid was removed
- All linting checks passed: `npm run lint:ts`, `npm run lint:md`, `npm run format:check`
- Build successfully verified with `npm run build`
- No breaking changes or dependencies modified