### PR TITLE
fix: [UI] modified the carousel effect for all features

### DIFF
--- a/src/components/TryNow/FeatureSection.tsx
+++ b/src/components/TryNow/FeatureSection.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Carousel } from 'react-responsive-carousel';
 import 'react-responsive-carousel/lib/styles/carousel.min.css';
 import { featureSectionAnimations } from '@/styles/Animations';
+import '@/styles/FeatureSection.css';
 
 interface FeatureData {
   title: string;
@@ -15,6 +16,7 @@ interface FeatureData {
 
 const FeatureSection = ({ data }: { data: FeatureData }) => {
   const [currentImage, setCurrentImage] = useState(0);
+  const hasMultipleImages = data.images && data.images.length > 1;
 
   return (
     <motion.section
@@ -43,36 +45,61 @@ const FeatureSection = ({ data }: { data: FeatureData }) => {
 
       {/* Right Side: Image Carousel */}
       <motion.div
-        className="md:w-1/2 flex flex-col justify-center items-center relative"
+        className="md:w-1/2 flex flex-col justify-center items-center"
         variants={featureSectionAnimations.imageContainer}
       >
         {data.images && data.images.length > 0 ? (
-          <Carousel
-            selectedItem={currentImage}
-            onChange={(index) => setCurrentImage(index)}
-            showThumbs={false}
-            showStatus={false}
-            infiniteLoop
-            autoPlay
-            interval={3000}
-            transitionTime={600}
-            emulateTouch
-            dynamicHeight
-          >
-            {data.images.map((image, index) => (
-              <motion.div key={index} className="w-full max-w-lg">
-                <motion.img
-                  src={image.src}
-                  alt={image.alt}
-                  className="w-full rounded-lg shadow-md"
-                  initial="hidden"
-                  animate="visible"
-                  whileHover="hover"
-                  variants={featureSectionAnimations.image}
-                />
-              </motion.div>
-            ))}
-          </Carousel>
+          <div className="relative group w-full">
+            <Carousel
+              selectedItem={currentImage}
+              onChange={(index) => setCurrentImage(index)}
+              showArrows={false}
+              showThumbs={false}
+              showStatus={false}
+              showIndicators={hasMultipleImages}
+              infiniteLoop={hasMultipleImages}
+              autoPlay={hasMultipleImages}
+              interval={3000}
+              transitionTime={600}
+              useKeyboardArrows={hasMultipleImages}
+              swipeable={hasMultipleImages}
+              emulateTouch={hasMultipleImages}
+            >
+              {data.images.map((image, index) => (
+                <motion.div key={index}>
+                  <motion.img
+                    src={image.src}
+                    alt={image.alt}
+                    className="w-full rounded-lg shadow-md"
+                    initial="hidden"
+                    animate="visible"
+                    whileHover="hover"
+                    variants={featureSectionAnimations.image}
+                  />
+                </motion.div>
+              ))}
+            </Carousel>
+
+            {/* LEFT hover zone */}
+            {hasMultipleImages && currentImage > 0 && (
+              <div
+                className="absolute left-0 top-0 h-full w-1/4 bg-gradient-to-r from-black/30 to-transparent opacity-0 group-hover:opacity-100 transition-all duration-300 cursor-pointer z-10"
+                onClick={() => setCurrentImage((prev) => prev - 1)}
+              >
+                <div className="absolute left-4 top-1/2 transform -translate-y-1/2 w-0 h-0 border-t-8 border-b-8 border-r-8 border-transparent border-r-white" />
+              </div>
+            )}
+
+            {/* RIGHT hover zone */}
+            {hasMultipleImages && currentImage < data.images.length - 1 && (
+              <div
+                className="absolute right-0 top-0 h-full w-1/4 bg-gradient-to-l from-black/30 to-transparent opacity-0 group-hover:opacity-100 transition-all duration-300 cursor-pointer z-10"
+                onClick={() => setCurrentImage((prev) => prev + 1)}
+              >
+                <div className="absolute right-4 top-1/2 transform -translate-y-1/2 w-0 h-0 border-t-8 border-b-8 border-l-8 border-transparent border-l-white" />
+              </div>
+            )}
+          </div>
         ) : (
           <motion.div
             className="w-full max-w-lg h-64 bg-gray-300 dark:bg-gray-700 rounded-lg flex items-center justify-center"

--- a/src/styles/FeatureSection.css
+++ b/src/styles/FeatureSection.css
@@ -1,0 +1,50 @@
+/* Enhanced Carousel Dot Indicators for feature sections (MusicBlock, TurtleBlock etc.)*/
+.carousel .control-dots {
+  position: absolute;
+  bottom: 12px;
+  margin: 0;
+  padding: 0;
+  text-align: center;
+  width: 100%;
+  z-index: 1;
+}
+
+.carousel .control-dots .dot {
+  width: 8px;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.5);
+  border-radius: 50%;
+  display: inline-block;
+  margin: 0 5px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+  opacity: 0.7;
+}
+
+.carousel .control-dots .dot.selected {
+  background: rgba(255, 255, 255, 0.95);
+  transform: scale(1.15);
+  opacity: 1;
+}
+
+.carousel .control-dots .dot:hover {
+  background: rgba(255, 255, 255, 0.8);
+  opacity: 0.9;
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+  .carousel .control-dots .dot {
+    background: rgba(255, 255, 255, 0.4);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+  }
+
+  .carousel .control-dots .dot.selected {
+    background: rgba(255, 255, 255, 0.9);
+  }
+
+  .carousel .control-dots .dot:hover {
+    background: rgba(255, 255, 255, 0.7);
+  }
+}


### PR DESCRIPTION
## Summary -
For all the additional features like `/musicblocks` `/turtleblocks` `/sugarizer` `/bootablesoas` `/trisquel` `/raspberry` `/flathub`, there are some carousel effects that are not consistent.

1. The carousel dots do not lie at the center of the image
2. The image does not cover the full width of the component
3.  The side arrows do not look very appealing
4. The arrows are far away from the image
5. There is an overall inconsistency that is clearly visible
6. **I tried to cover those issues and tried to make the whole carousel workflow look elegant.** by making changes in the `**FeatureSection.tsx**`

## Visuals 

### Before
You will see that the right arrow appears to be far away from the image, and the carousel dots do not lie at the center of the image

**Dark mode**

<img width="1838" height="673" alt="image" src="https://github.com/user-attachments/assets/e20a9966-dfb3-41d9-9896-02064521ba51" />

**Light mode**

<img width="1864" height="669" alt="image" src="https://github.com/user-attachments/assets/a5de1dbf-8051-45a8-95e0-c0252e42ef7a" />

### After 
The arrows are now aligned on top of the image, and the carousel dots are at the center of the image

**Dark mode**

<img width="1880" height="746" alt="image" src="https://github.com/user-attachments/assets/9a7a30bd-7562-403e-9ef0-9b611a1b6a1b" />

<img width="1879" height="727" alt="image" src="https://github.com/user-attachments/assets/da494388-cebd-4f62-bdd6-faf4adf366dc" />

**Light mode**

<img width="1884" height="736" alt="image" src="https://github.com/user-attachments/assets/2d114a00-7626-4712-b990-9ced97acf4ec" />

<img width="1877" height="738" alt="image" src="https://github.com/user-attachments/assets/66d6cfca-c57f-4883-b966-760df3ec595f" />


### I have made these changes for all the possible components that have this issue. In case I forgot anything or have any suggestions, feel free to comment.