### PR TITLE
fix: [UI] made the UI of go back button on tryNow page more appealing

### DIFF
--- a/src/pages/TrySugar.tsx
+++ b/src/pages/TrySugar.tsx
@@ -2,6 +2,8 @@ import Header from '@/sections/Header';
 import Footer from '@/sections/Footer';
 import Try from '@/components/Try';
 import { useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { ArrowLeft } from 'lucide-react';
 
 const TrySugar = () => {
   const navigate = useNavigate();
@@ -14,12 +16,15 @@ const TrySugar = () => {
       <Header />
       <main className="flex-grow bg-[#F6DEC9] dark:bg-gray-950/95 p-4">
         <div className="max-w-6xl mx-auto space-y-8">
-          <button
-            onClick={goBack}
-            className="text-sm text-blue-600 hover:underline mb-4"
+          <motion.button
+            onClick={() => goBack()}
+            className="mb-6 px-4 py-2 flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors rounded-md hover:bg-[#F3D5B9] dark:hover:bg-blue-950/30"
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
           >
-            ← Back
-          </button>
+            <ArrowLeft className="h-5 w-5 mr-2" />
+            Back
+          </motion.button>
 
           <Try />
         </div>


### PR DESCRIPTION
## Summary

This is just a UI enhancement of a previous PR https://github.com/sugarlabs/www-v2/pull/743

## Visuals

### Before

**Light mode**

<img width="174" height="76" alt="image" src="https://github.com/user-attachments/assets/946c4d44-782b-4f5c-a22b-1f3b401fe04f" />

<img width="170" height="80" alt="image" src="https://github.com/user-attachments/assets/67fa5412-e2f2-4d5b-9851-98d35adf7d90" />


**Dark mode**

<img width="220" height="78" alt="image" src="https://github.com/user-attachments/assets/0eb685c7-29ca-47ab-837f-b84a22c78641" />

<img width="203" height="89" alt="image" src="https://github.com/user-attachments/assets/82cd5e51-3bb1-4b8c-a6d2-cdb4058b4b67" />


### After

**Light mode**

<img width="210" height="104" alt="image" src="https://github.com/user-attachments/assets/243c34e9-00ab-4358-a37c-74979f730d29" />

<img width="180" height="95" alt="image" src="https://github.com/user-attachments/assets/8ad2c90e-1fbf-4010-b0ad-29f65cbb80ab" />


**Dark mode**

<img width="202" height="92" alt="image" src="https://github.com/user-attachments/assets/bc4cd1e3-ae40-43ec-9fed-8f31425bbabe" />

<img width="230" height="102" alt="image" src="https://github.com/user-attachments/assets/f17d1472-43ce-4152-9217-4e6443906128" />


### Before the manual button and left arrow were being used, I added `<motion.button />` for the button and `ArrowLeft` from `lucide-react` to make the changes