### PR TITLE
allow marquee to be paused on touch devices

### DIFF
--- a/src/components/magicui/Marquee.tsx
+++ b/src/components/magicui/Marquee.tsx
@@ -41,13 +41,13 @@ export function Marquee({
   repeat = 4,
   ...props
 }: MarqueeProps) {
-  const [isPaused, setIsPaused] = useState(false)
+  const [isPaused, setIsPaused] = useState(false);
 
   const handlePointerDown = (e: React.PointerEvent) => {
     if (e.pointerType === 'touch') {
-      setIsPaused(p => !p)
+      setIsPaused((p) => !p);
     }
-  }
+  };
 
   return (
     <div
@@ -67,16 +67,13 @@ export function Marquee({
         .map((_, i) => (
           <div
             key={i}
-            className={cn(
-              'flex shrink-0 justify-around [gap:var(--gap)]',
-              {
-                'animate-marquee flex-row': !vertical,
-                'animate-marquee-vertical flex-col': vertical,
-                'group-hover:[animation-play-state:paused]': pauseOnHover,
-                '[animation-direction:reverse]': reverse,
-                '[animation-play-state:paused]': isPaused,
-              }
-            )}
+            className={cn('flex shrink-0 justify-around [gap:var(--gap)]', {
+              'animate-marquee flex-row': !vertical,
+              'animate-marquee-vertical flex-col': vertical,
+              'group-hover:[animation-play-state:paused]': pauseOnHover,
+              '[animation-direction:reverse]': reverse,
+              '[animation-play-state:paused]': isPaused,
+            })}
           >
             {children}
           </div>


### PR DESCRIPTION
---
name: Pull Request
about: Submit changes to the Sugar Labs website for review
---

## 📝 Description

The marquee currently relies on hover to pause the animation. This works on desktop but fails on touch devices, where hover is not available, making the testimonials difficult to read.

This PR adds tap-to-pause support for touch devices while preserving the existing hover-to-pause behaviour on desktop. Mobile users can now tap the marquee to pause and resume the animation, improving usability and accessibility.

<!--- Provide a clear and concise description of your changes. -->
<!--- Explain what problem it solves or what feature/improvement it adds. -->


## 🔗 Related Issue

<!--- If this PR is related to any issue(s), link them here using #issue_number -->
<!--- For example: "Fixes #123" or "Part of #456" -->

Fixes #754

## 🔄 Type of Change

<!--- What types of changes does your code introduce? Put an `x` in all boxes that apply: -->

- [x] 📱 New Feature (new page, component, or functionality)
- [x] 🎨 UI/UX Update (visual changes, styling improvements)
- [ ] 📖 Content Update (text changes, documentation)
- [x] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [ ] ♿ Accessibility Enhancement
- [ ] 🔒 Security Update
- [ ] 📦 Dependency Update
- [ ] 🧹 Code Refactoring
- [ ] 🧪 Test Updates

## 📷 Visual Changes

<!--- If your changes affect the website's appearance, please provide screenshots -->
<!--- For UI changes, include before/after screenshots if possible -->

<details>
The provided Image shows a static marquee after being clicked on; clicking again will resume the flow.
<summary>Screenshots / GIFs</summary>

<!-- Drag and drop your screenshots here -->
<img width="1512" height="861" alt="Screenshot 2026-01-11 at 3 14 12 PM" src="https://github.com/user-attachments/assets/d41f66b3-0a40-403b-8c09-03bcf5e5ca0f" />

</details>

## 🧪 Testing Performed

### 📱 Browser Compatibility

<!--- Check all browsers where you've tested these changes -->

- [x] Chrome (Version: latest)
- [ ] Firefox (Version: )
- [x] Safari (Version: latest)
- [ ] Edge (Version: )
- [x] Mobile Chrome (Device: latest)
- [ ] Mobile Safari (Device: )

### 🖥️ Responsive Design

<!--- Confirm testing on different screen sizes -->

- [x] Desktop (1200px+)
- [x] Tablet (768px - 1199px)
- [x] Mobile (320px - 767px)

### ✅ Test Cases

<!--- List the specific test cases you've verified -->

1. On desktop, hovering over the marquee pauses the animation and un-hover resumes it.
2. On mobile, tapping the marquee pauses the animation.
3. Tapping again on the mobile resumes the animation.

## ♿ Accessibility

<!--- Confirm accessibility requirements are met -->

- [x] Proper heading hierarchy maintained
- [x] ARIA labels added where needed
- [x] Color contrast requirements met
- [x] Keyboard navigation works correctly
- [x] Screen reader testing performed

## 📋 PR Checklist

<!--- Review and check all applicable items -->

- [x] My code follows the project's coding style guidelines
- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or console errors
- [x] I have added tests that prove my fix/feature works
- [x] All existing tests pass successfully
- [x] I have checked for and resolved any merge conflicts
- [x] I have optimized images/assets (if applicable)
- [x] I have validated all links are working correctly

## 💭 Additional Notes

<!--- Add any additional context, considerations, or notes for reviewers -->
This change uses pointer events to detect touch input, ensuring that desktop mouse interactions are unaffected while enabling proper pause behavior on mobile and tablet devices.

---

### 📚 Reviewer Resources

- [Contributing Guide](https://github.com/sugarlabs/www-v2/blob/main/docs/CONTRIBUTING.md)
- [Style Guide](https://github.com/sugarlabs/www-v2/blob/main/docs/dev_guide.md)
- [Community Chat](https://matrix.to/#/#sugarlabs-web:matrix.org)

Thank you for contributing to the Sugar Labs website! 🎉
