### PR TITLE
Fix dark mode lag by optimizing transitions and fixing globals.css

### DIFF
--- a/src/sections/Header.tsx
+++ b/src/sections/Header.tsx
@@ -65,10 +65,10 @@ const Header: React.FC = () => {
   return (
     <>
       <header
-        className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
+        className={`fixed top-0 left-0 right-0 z-50 transition-colors duration-300 ${
           isScrolled
             ? 'backdrop-blur-md bg-white/90 dark:bg-gray-900/80 shadow-lg'
-            : 'bg-white dark:bg-gray-900'
+            : 'bg-white/0 dark:bg-gray-900/0'
         }`}
       >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -143,7 +143,7 @@ const Header: React.FC = () => {
                     key={link.label}
                     to={link.path}
                     className={`px-2 lg:px-2 py-2 font-medium rounded-md
-                              transition-all duration-200 hover:bg-gray-50 dark:hover:bg-gray-800 text-sm lg:text-sm whitespace-nowrap
+                              transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-800 text-sm lg:text-sm whitespace-nowrap
                               ${isActive ? 'text-blue-600 dark:text-blue-400' : 'text-gray-700 dark:text-gray-200 hover:text-blue-600'}`}
                     onClick={handleNavigation}
                   >
@@ -233,7 +233,7 @@ const MobileNavDrawer: React.FC<{
                           setActiveDropdown(activeDropdown === key ? null : key)
                         }
                         className="flex items-center justify-between w-full text-left px-2 py-2
-                              text-gray-700 dark:text-gray-200 font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800"
+                              text-gray-700 dark:text-gray-200 font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors duration-200"
                         aria-expanded={activeDropdown === key}
                       >
                         <span>{dropdown.label}</span>
@@ -276,7 +276,7 @@ const MobileNavDrawer: React.FC<{
                                     to={item.path}
                                     onClick={onClose}
                                     className={`flex items-center px-4 py-2 text-sm rounded-lg
-                                        hover:bg-gray-50 dark:hover:bg-gray-800 hover:text-blue-600
+                                        hover:bg-gray-50 dark:hover:bg-gray-800 hover:text-blue-600 transition-colors duration-200
                                         ${isItemActive ? 'text-blue-600 dark:text-blue-400 bg-gray-50 dark:bg-gray-800' : 'text-gray-600 dark:text-gray-300'}`}
                                   >
                                     {item.label}

--- a/src/sections/NavDropdown.tsx
+++ b/src/sections/NavDropdown.tsx
@@ -29,7 +29,7 @@ const NavDropdown: React.FC<NavDropdownProps> = ({
     >
       <button
         className={`px-2 lg:px-3 py-2 text-gray-700 dark:text-gray-200 hover:text-blue-600 font-medium rounded-md
-                  transition-all duration-200 hover:bg-gray-50 dark:hover:bg-gray-800 flex items-center space-x-1
+                  transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-800 flex items-center space-x-1
                   ${isActive ? 'text-blue-600 dark:text-blue-400' : ''}`}
         aria-expanded={isActive}
       >
@@ -69,13 +69,13 @@ const NavDropdown: React.FC<NavDropdownProps> = ({
                     to={item.path}
                     onClick={onNavigate}
                     className={`group flex items-center px-4 py-3 text-sm
-                            transition-all duration-200 hover:bg-gray-50 dark:hover:bg-gray-700
+                            transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-700
                             hover:text-blue-600 dark:hover:text-blue-400
                             ${isItemActive ? 'text-blue-600 dark:text-blue-400 bg-gray-50 dark:bg-gray-700' : 'text-gray-700 dark:text-gray-300'}`}
                   >
                     <span
                       className={`w-2 h-2 rounded-full bg-blue-600 mr-2 transform
-                                transition-all duration-200
+                                transition-opacity duration-200
                                 ${isItemActive ? 'opacity-100 scale-100' : 'opacity-0 scale-0 group-hover:opacity-100 group-hover:scale-100'}`}
                     />
                     {item.label}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -184,7 +184,7 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground transition-colors duration-300;
   }
 }
 


### PR DESCRIPTION
This PR addresses significant performance lag experienced when toggling between Dark and Light modes, caused by the expensive [transition-all](vscode-file://vscode-app/c:/Users/karn0/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) property on navigation elements. It also ensures the Navbar and the rest of the website transition seamlessly together.


Before:


https://github.com/user-attachments/assets/e1a953ee-7f2f-40e2-a387-c5e0967c8756



Significant lag/jank when clicking the theme toggle.
Navbar background and website body changed colors at slightly different times/speeds.



After:

https://github.com/user-attachments/assets/c2f82a5f-b6c3-4bf4-b224-873ffb6cd3b0


Instant, buttery smooth theme switching with zero lag.
Navbar and page background fade simultaneously in perfect sync.