### PR TITLE
fix(FlatHub): replace invalid clamp() with responsive classes

### DIFF
--- a/src/pages/TryNow/FlatHub.tsx
+++ b/src/pages/TryNow/FlatHub.tsx
@@ -40,7 +40,7 @@ const FlatHubPage = () => {
         <img
           src="assets/FloatingSVGs/flathub-2.svg"
           alt="Flathub SVG 2"
-          className="w-[clamp(40px,9vw,16px)]"
+          className="w-10 sm:w-12 md:w-16"
         />
       </motion.div>
 


### PR DESCRIPTION
 Fixes #766                                                                                             
                                                                                                         
  Changes:                                                                                               
  - Replaced invalid clamp(40px, 9vw, 16px) with responsive Tailwind classes                             
  - The original clamp had min > max which is invalid CSS                                                
                                                                                                         
  Testing:                                                                                               
  - Build passes                                                                                         
  - FlatHub page renders correctly 