### PR TITLE
fix: [UI]added-skeleton-loading-for-individual-articles

### DIFF
--- a/src/components/skeletons/ArticlesSkeleton.tsx
+++ b/src/components/skeletons/ArticlesSkeleton.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const ArticleSkeleton: React.FC = () => {
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-4xl bg-white dark:bg-gray-900 mt-10 rounded-lg">
+      {/* No back button skeleton - it will only appear when content loads */}
+
+      {/* Article Header Skeleton */}
+      <div className="mb-6"></div>
+      <div className="mb-8 border-b border-gray-200 dark:border-gray-700 pb-6">
+        {/* Category Badge */}
+        <div className="mb-4">
+          <div className="h-7 w-32 bg-gray-200 dark:bg-gray-800 rounded-full relative overflow-hidden inline-block">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+        </div>
+
+        {/* Title Skeleton */}
+        <div className="mb-4 space-y-3">
+          <div className="h-10 w-full bg-gray-200 dark:bg-gray-800 rounded-md relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-10 w-4/5 bg-gray-200 dark:bg-gray-800 rounded-md relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+        </div>
+
+        {/* Metadata Row (Date & Author) */}
+        <div className="flex items-center mb-3 gap-4">
+          <div className="h-4 w-28 bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-4 w-1 bg-gray-300 dark:bg-gray-700 rounded"></div>
+          <div className="h-4 w-32 bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+        </div>
+
+        {/* Tags Skeleton */}
+        <div className="flex flex-wrap gap-2 mt-3">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-6 w-20 bg-gray-200 dark:bg-gray-800 rounded-md relative overflow-hidden"
+            >
+              <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Featured Image Skeleton */}
+      <motion.div
+        className="mb-8 rounded-lg overflow-hidden shadow-lg max-w-2xl mx-auto"
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        <div className="w-full h-80 bg-gray-200 dark:bg-gray-800 relative overflow-hidden">
+          <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+        </div>
+      </motion.div>
+
+      {/* Article Content Skeleton */}
+      <motion.div
+        className="mb-12 space-y-6"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5 }}
+      >
+        {/* Paragraph 1 */}
+        <div className="space-y-2">
+          <div className="h-4 w-full bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-4 w-full bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-4 w-11/12 bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-4 w-full bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-4 w-9/12 bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+        </div>
+
+        {/* Paragraph 2 */}
+        <div className="space-y-2">
+          <div className="h-4 w-full bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-4 w-full bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-4 w-10/12 bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+        </div>
+
+        {/* Subheading */}
+        <div className="pt-4">
+          <div className="h-7 w-2/3 bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+        </div>
+
+        {/* Paragraph 3 */}
+        <div className="space-y-2">
+          <div className="h-4 w-full bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-4 w-full bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-4 w-full bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-4 w-8/12 bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+        </div>
+
+        {/* Paragraph 4 */}
+        <div className="space-y-2">
+          <div className="h-4 w-full bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-4 w-full bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-4 w-9/12 bg-gray-200 dark:bg-gray-800 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+        </div>
+      </motion.div>
+
+      {/* Author Bio Skeleton */}
+      <motion.div
+        className="bg-blue-50 dark:bg-gray-800 rounded-lg p-6 my-8 flex items-center space-x-4"
+        whileHover={{ scale: 1.02 }}
+      >
+        {/* Avatar Circle */}
+        <div className="w-16 h-16 flex-shrink-0 bg-gray-200 dark:bg-gray-700 rounded-full relative overflow-hidden">
+          <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-600/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+        </div>
+        <div className="flex-1 space-y-2">
+          <div className="h-5 w-32 bg-gray-200 dark:bg-gray-700 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-600/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-4 w-full bg-gray-200 dark:bg-gray-700 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-600/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+          <div className="h-4 w-3/4 bg-gray-200 dark:bg-gray-700 rounded relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-600/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+          </div>
+        </div>
+      </motion.div>
+
+      {/* Tags Section Skeleton */}
+      <div className="border-t border-gray-200 dark:border-gray-700 pt-6 mb-8">
+        <div className="h-6 w-20 bg-gray-200 dark:bg-gray-800 rounded mb-4 relative overflow-hidden">
+          <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {[1, 2, 3, 4].map((i) => (
+            <div
+              key={i}
+              className="h-8 w-24 bg-gray-200 dark:bg-gray-800 rounded-full relative overflow-hidden"
+            >
+              <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 dark:via-gray-700/30 to-transparent animate-[shimmer_2s_infinite]"></div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ArticleSkeleton;

--- a/src/pages/News/NewsDetailPage.tsx
+++ b/src/pages/News/NewsDetailPage.tsx
@@ -7,6 +7,7 @@ import { getPostBySlug, Post } from '@/utils/posts-utils';
 import Header from '@/sections/Header';
 import Footer from '@/sections/Footer';
 import MarkdownRenderer from '@/utils/MarkdownRenderer';
+import ArticleSkeleton from '@/components/skeletons/ArticlesSkeleton';
 
 const NewsDetailPage: React.FC = () => {
   const [shareModalOpen, setShareModalOpen] = useState(false);
@@ -122,14 +123,7 @@ const NewsDetailPage: React.FC = () => {
     return (
       <>
         <Header />
-        <div className="container mx-auto px-4 py-16 flex justify-center items-center min-h-screen bg-white dark:bg-gray-900">
-          <div className="flex flex-col items-center">
-            <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-blue-600 dark:border-blue-400 mb-4"></div>
-            <p className="text-gray-600 dark:text-gray-400">
-              Loading article...
-            </p>
-          </div>
-        </div>
+        <ArticleSkeleton />
         <Footer />
       </>
     );


### PR DESCRIPTION
## Summary

Replace the loading spinner on `/news/:category/:slug` pages with skeleton loading components that match the style and behavior of the Individual Articles page.

### Building on the previous enhancement

- This PR extends the skeleton loading for the `/news/:category/:slug` route to make it more consistent.
- This follows the loading style convention of the `/news` route, as this route also follows the skeleton loading. 
- This skeleton follows the page layout after the contents load 

## Visuals 

### Before

**Dark mode**

<img width="1419" height="747" alt="image" src="https://github.com/user-attachments/assets/e68d4495-468b-409b-b3e1-ccf61d504f0b" />

**Light mode**

<img width="1464" height="765" alt="image" src="https://github.com/user-attachments/assets/b1951a0c-f1da-4d28-858b-b462cfae42c0" />

### After

**Dark mode**

<img width="1650" height="768" alt="image" src="https://github.com/user-attachments/assets/5db8c38c-2a61-4664-a190-676839c8639f" />

<img width="1704" height="773" alt="image" src="https://github.com/user-attachments/assets/cceb8f0e-4019-44b2-a8fa-7fbe5175c9bb" />

<img width="1680" height="766" alt="image" src="https://github.com/user-attachments/assets/3ab5e2d0-fa14-45f0-94c6-5a7263566ce2" />


**Light mode**

<img width="1639" height="758" alt="image" src="https://github.com/user-attachments/assets/c51c9578-5771-44de-8456-3237cf04d205" />

<img width="1663" height="758" alt="image" src="https://github.com/user-attachments/assets/00258ad9-2607-4bff-bea2-6421d5e5d773" />

<img width="1685" height="788" alt="image" src="https://github.com/user-attachments/assets/0444d6ac-9288-4e33-9928-6e26627716d8" />

### Design Consistency

- This implementation exactly matches the skeleton loading from PR https://github.com/sugarlabs/www-v2/pull/694
- The Skeleton follows the exact layout of the page after loading. The Dynamic bits, too.
