### PR TITLE
fix: isolate hover effects to individual statistic cards

### DIFF
--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -270,7 +270,10 @@ const Stats = () => {
                   maxHeight: isActive || isHovered ? 500 : 80, // 500 is big enough for long text
                   paddingTop: isActive || isHovered ? 16 : 8,
                   paddingBottom: isActive || isHovered ? 16 : 8,
-                  boxShadow: isActive || isHovered ? '0 12px 25px rgba(0,0,0,0.18)' : '0 0px 0px rgba(0,0,0,0)',
+                  boxShadow:
+                    isActive || isHovered
+                      ? '0 12px 25px rgba(0,0,0,0.18)'
+                      : '0 0px 0px rgba(0,0,0,0)',
                 }}
                 transition={{ type: 'spring', stiffness: 400, damping: 30 }}
                 onClick={(e) => {
@@ -293,8 +296,6 @@ const Stats = () => {
                   e.stopPropagation();
                 }}
               >
-
-
                 <motion.div
                   className="flex flex-col items-center justify-center"
                   transition={{ type: 'spring', stiffness: 400, damping: 10 }}
@@ -306,7 +307,7 @@ const Stats = () => {
                   </span>
 
                   <div className="w-full overflow-hidden">
-                    <AnimatePresence mode='sync'>
+                    <AnimatePresence mode="sync">
                       {!showFullText ? (
                         <motion.span
                           key={`truncated-${index}`}
@@ -315,7 +316,6 @@ const Stats = () => {
                           animate={{ opacity: 1 }}
                           exit={{ opacity: 0 }}
                         >
-
                           {stat.title.split('.')[0].substring(0, 12)}
                           {stat.title.split('.')[0].length > 12 ? '...' : ''}
                         </motion.span>
@@ -327,15 +327,12 @@ const Stats = () => {
                           animate={{ opacity: 1 }}
                           exit={{ opacity: 0 }}
                         >
-
                           {stat.title}
                         </motion.span>
                       )}
                     </AnimatePresence>
-
                   </div>
                 </motion.div>
-
               </motion.div>
             );
           })}


### PR DESCRIPTION
This PR fixes a UI bug in the "Join us and make a difference" section (Impact Statistics).

The Problem: Previously, the hover animation was applied to the entire container or shared a state/class that caused all statistic cards to trigger their hover effect simultaneously when any single card was hovered.

The Solution: I have updated the styling logic to ensure that hover transitions are scoped to the individual card level. Now, only the specific card being interacted with will scale/highlight, providing clearer visual feedback to the user.

🔗 Related Issue
Fixes # ## 🔄 Type of Change

[ ] 📱 New Feature (new page, component, or functionality)

[x] 🎨 UI/UX Update (visual changes, styling improvements)

[ ] 📖 Content Update (text changes, documentation)

[x] 🐛 Bug Fix

[ ] ⚡ Performance Improvement

[ ] ♿ Accessibility Enhancement

[ ] 🔒 Security Update

[ ] 📦 Dependency Update

[ ] 🧹 Code Refactoring

[ ] 🧪 Test Updates

📷 Visual Changes
<details> <summary>Screenshots / GIFs</summary>

Before: 
<img width="1512" height="982" alt="Screenshot 2026-01-13 at 22 59 48" src="https://github.com/user-attachments/assets/ec276f13-2aba-4356-b7aa-983d5c7d5d7c" />


After: 
<img width="1512" height="982" alt="Screenshot 2026-01-13 at 23 03 27" src="https://github.com/user-attachments/assets/3303468a-5180-4712-8333-1e05b91d8806" />

</details>

🧪 Testing Performed
📱 Browser Compatibility
[x] Chrome (Version: Latest)

[x] Firefox (Version: Latest)

[ ] Safari (Version: )

[ ] Edge (Version: )

🖥️ Responsive Design
[x] Desktop (1200px+)

[x] Tablet (768px - 1199px)

[x] Mobile (320px - 767px)

✅ Test Cases
Hover over the "3,000,000+ Kids" card and verify only that card scales.

Hover over the "170 Languages" card and verify the blue border/scale effect is isolated to that card.

Ensure no layout shifting occurs in the rest of the grid when a single card is hovered.

📋 PR Checklist
[x] My code follows the project's coding style guidelines

[x] I have tested these changes locally

[x] I have updated the documentation accordingly

[x] My changes generate no new warnings or console errors

[x] I have checked for and resolved any merge conflicts
@SaaiAravindhRaja @sa-fw-an 