### PR TITLE
fix: Change Matrix route from dynamic to static path (#776)

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -54,7 +54,7 @@ const router = createBrowserRouter([
   { path: '/raspberry', element: <RaspberryPiPage /> },
   { path: '/musicblocks', element: <MusicBlocksPage /> },
   { path: '/flathub', element: <FlatHubPage /> },
-  { path: '/contact-us/:matrix', element: <Matrix /> },
+  { path: '/contact-us/matrix', element: <Matrix /> },
   { path: '/profiles', element: <Contributors /> },
   { path: '*', element: <NotFoundPage /> },
 ]);


### PR DESCRIPTION
## Description
Fixes issue #776 

## Changes Made
- Changed `/contact-us/:matrix` to `/contact-us/matrix` in `src/routes.tsx`
- The Matrix component doesn't use the `:matrix` parameter, making the dynamic route unnecessary

## Problem Fixed
- **Before:** Any URL matching `/contact-us/*` (e.g., `/contact-us/help`, `/contact-us/support`) incorrectly rendered the Matrix page
- **After:** Only `/contact-us/matrix` shows the Matrix page; all other `/contact-us/*` paths correctly show 404

## Testing
- [x] `/contact-us` → ContactUs page
- [x] `/contact-us/matrix` → Matrix page  
- [x] `/contact-us/anything-else` → 404 page

## Impact
- Prevents broken links from being masked
- Fixes SEO issues where search engines could index Matrix page under incorrect URLs
- Ensures proper 404 handling for invalid paths