### PR TITLE
fix: closes share modal on outside click

### DIFF
--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -151,8 +151,17 @@ const ShareModal: React.FC<ShareModalProps> = ({
     }
   };
 
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-transparent transition-all backdrop-blur-sm">
+    <div
+      onClick={handleBackdropClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent transition-all backdrop-blur-sm"
+    >
       <div className="relative w-full max-w-sm mx-auto bg-gradient-to-br from-blue-50 via-white to-green-50 rounded-2xl shadow-2xl p-7 animate-fadeIn border border-blue-100">
         <button
           className="absolute top-4 right-4 text-gray-500 hover:text-blue-600 bg-white rounded-full shadow p-1 cursor-pointer transition-colors duration-200 border border-gray-200"


### PR DESCRIPTION
## 📝 Description

### On the News page, each news card includes a share icon that opens a share modal. While the modal can be closed using the `Esc` key and obviously the cross, but clicking outside the modal `(backdrop area)` does not close it.

This behavior is inconsistent with common modal UX patterns and may feel confusing, especially for users on mobile devices.

## Implemented Changes:

### Clicking outside the modal should closes it _making the interaction more intuitive for users._


## 🔗 Related Issue


Fixes #782 

## 🔄 Type of Change

- [ ] 📱 New Feature (new page, component, or functionality)
- [x] 🎨 UI/UX Update (visual changes, styling improvements)
- [ ] 📖 Content Update (text changes, documentation)
- [x] 🐛 Bug Fix
- [x] ⚡ Performance Improvement
- [x] ♿ Accessibility Enhancement
- [ ] 🔒 Security Update
- [ ] 📦 Dependency Update
- [ ] 🧹 Code Refactoring
- [ ] 🧪 Test Updates

## 📷 Visual Changes

# Do watch this screenRecording, for the before behaviour, and after results, and experience the implementation.

https://github.com/user-attachments/assets/c87a96df-777f-4ab6-bdee-dc4ac4e36cc9

## 🧪 Testing Performed

### 📱 Browser Compatibility

- [x] Chrome (Version: )
- [x] Safari (Version: )
- [x] Edge (Version: )
- [x] Mobile Chrome (Device: )

### 🖥️ Responsive Design

- [x] Desktop (1200px+)
- [x] Tablet (768px - 1199px)
- [x] Mobile (320px - 767px)

### ✅ Test Cases

<!--- List the specific test cases you've verified -->

1. `npm run lint:ts`
2. `npm run lint:md`
3. `npm run format`

## ♿ Accessibility

- [x] Proper heading hierarchy maintained
- [x] ARIA labels added where needed
- [x] Color contrast requirements met
- [x] Keyboard navigation works correctly
- [x] Screen reader testing performed

## 📋 PR Checklist

- [x] My code follows the project's coding style guidelines
- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or console errors
- [ ] I have added tests that prove my fix/feature works
- [x] All existing tests pass successfully
- [x] I have checked for and resolved any merge conflicts
- [ ] I have optimized images/assets (if applicable)
- [x] I have validated all links are working correctly

---
