### PR TITLE
fix: [UI]button-layout-fixed

### DIFF
--- a/src/pages/More.tsx
+++ b/src/pages/More.tsx
@@ -11,6 +11,7 @@ import Header from '@/sections/Header';
 import Footer from '@/sections/Footer';
 import MarkdownRenderer from '@/utils/MarkdownRenderer';
 import MorePageSkeleton from '@/components/skeletons/MorePageSkeleton';
+import { ArrowLeft } from 'lucide-react';
 
 const MorePage: React.FC = () => {
   const { slug } = useParams<{ slug: string }>();
@@ -132,25 +133,14 @@ const MorePage: React.FC = () => {
         <div className="mb-8">
           <Link
             to="/"
-            className="text-blue-600 hover:underline mb-2 inline-block"
+            className="text-blue-600 hover:no-underline mb-2 inline-block"
           >
             <motion.button
-              className="mb-6 px-4 py-2 flex items-center text-blue-600 hover:text-blue-700 transition-colors rounded-md hover:bg-blue-50"
+              className="mb-6 px-4 py-2 flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors rounded-md hover:bg-blue-50 dark:hover:bg-blue-900/30"
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-5 w-5 mr-2"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M9.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L7.414 9H15a1 1 0 110 2H7.414l2.293 2.293a1 1 0 010 1.414z"
-                  clipRule="evenodd"
-                />
-              </svg>
+              <ArrowLeft className="h-5 w-5 mr-2" />
               Back to Home
             </motion.button>
           </Link>


### PR DESCRIPTION
## Summary

Madethe UI of the "Go to Home" button at the `/more/` route (`/more/culture`, `more/students`, `/more/parents`, and `/more/school-admin`) match the existing style pattern and color palette. The button looked good when set idle. However, when hovered, it showed a little inconsistency.


## Visuals

### Before

<img width="170" height="64" alt="image" src="https://github.com/user-attachments/assets/5956fcf1-334f-4d55-91fb-5788dacc6ed8" />

<img width="211" height="83" alt="image" src="https://github.com/user-attachments/assets/f032a21c-b64d-46dc-8691-e160c03460e5" />

**After**

<img width="197" height="78" alt="image" src="https://github.com/user-attachments/assets/e333091f-2326-4821-9939-2ffa0cf53eda" />

<img width="225" height="90" alt="image" src="https://github.com/user-attachments/assets/43b3b867-4560-489c-8a67-b671dce706ad" />

**Everything looks fine for light mode, so no changes are made for that**