### PR TITLE
fix: Arrow icons misalignment fix on `/join-development`

### DIFF
--- a/src/components/DeveloperLinks.tsx
+++ b/src/components/DeveloperLinks.tsx
@@ -103,7 +103,6 @@ const DeveloperLinks = () => {
             >
               <span
                 className="
-                    -mt-1
                     text-gray-800 dark:text-gray-800
                     group-hover:text-red-700 dark:group-hover:text-orange-600
                     transform group-hover:translate-x-1


### PR DESCRIPTION

## 📝 Description

## Removed the `-mt-1` tailwind class which was causing this issue: (in `/src/components/DeveloperLinks.tsx`)


## 🔗 Related Issue

Fixes #791 

## 🔄 Type of Change


- [ ] 📱 New Feature (new page, component, or functionality)
- [x] 🎨 UI/UX Update (visual changes, styling improvements)
- [ ] 📖 Content Update (text changes, documentation)
- [x] 🐛 Bug Fix
- [x] ⚡ Performance Improvement
- [x] ♿ Accessibility Enhancement
- [ ] 🔒 Security Update
- [ ] 📦 Dependency Update
- [ ] 🧹 Code Refactoring
- [ ] 🧪 Test Updates

## 📷 Visual Changes

# Now this is fixed, do look carefully, although further im attaching easy to understand the difference screenshots:

https://github.com/user-attachments/assets/2a608f6a-30a3-4f89-a428-1e0c93fb12a9


## 🧪 Testing Performed

### 📱 Browser Compatibility


- [x] Chrome (Version: )
- [x] Firefox (Version: )
- [x] Safari (Version: )
- [x] Edge (Version: )
- [x] Mobile Chrome (Device: )

### 🖥️ Responsive Design


- [x] Desktop (1200px+)
- [x] Tablet (768px - 1199px)
- [x] Mobile (320px - 767px)

### ✅ Test Cases

<!--- List the specific test cases you've verified -->

1. `npm run lint:ts`
2. `npm run lint:md`
3. `npm run format`

## ♿ Accessibility


- [x] Proper heading hierarchy maintained
- [x] ARIA labels added where needed
- [x] Color contrast requirements met
- [x] Keyboard navigation works correctly
- [x] Screen reader testing performed

## 📋 PR Checklist

- [x] My code follows the project's coding style guidelines
- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or console errors
- [x] I have added tests that prove my fix/feature works
- [x] All existing tests pass successfully
- [x] I have checked for and resolved any merge conflicts
- [x] I have optimized images/assets (if applicable)
- [x] I have validated all links are working correctly

---
