### PR TITLE
fix(marquee): pause animation on mobile touch events

### DIFF
--- a/src/components/magicui/Marquee.tsx
+++ b/src/components/magicui/Marquee.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/utils';
-import { ComponentPropsWithoutRef } from 'react';
+import { ComponentPropsWithoutRef, useState } from 'react';
 
 interface MarqueeProps extends ComponentPropsWithoutRef<'div'> {
   /**
@@ -41,6 +41,20 @@ export function Marquee({
   repeat = 4,
   ...props
 }: MarqueeProps) {
+  const [isPaused, setIsPaused] = useState(false);
+
+  const handleTouchStart = () => {
+    if (pauseOnHover) {
+      setIsPaused(true);
+    }
+  };
+
+  const handleTouchEnd = () => {
+    if (pauseOnHover) {
+      setIsPaused(false);
+    }
+  };
+
   return (
     <div
       {...props}
@@ -52,6 +66,8 @@ export function Marquee({
         },
         className,
       )}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
     >
       {Array(repeat)
         .fill(0)
@@ -62,6 +78,7 @@ export function Marquee({
               'animate-marquee flex-row': !vertical,
               'animate-marquee-vertical flex-col': vertical,
               'group-hover:[animation-play-state:paused]': pauseOnHover,
+              '[animation-play-state:paused]': pauseOnHover && isPaused,
               '[animation-direction:reverse]': reverse,
             })}
           >


### PR DESCRIPTION
---
name: Pull Request
about: Submit changes to the Sugar Labs website for review
---

## 📝 Description

Fixes a bug where the Marquee component's `pauseOnHover` feature wasn't working on mobile devices. On desktop, hovering over the testimonials correctly pauses the animation, but on mobile touch screens, the animation continued even when users tried to interact with the content.

This fix adds touch event handlers (`onTouchStart` and `onTouchEnd`) to the Marquee component, enabling the pause functionality on mobile devices while maintaining the existing hover behavior on desktop.

## 🔗 Related Issue

<!--- If this PR is related to any issue(s), link them here using #issue_number -->
<!--- For example: "Fixes #123" or "Part of #456" -->

No related issue - discovered during manual testing.

## 🔄 Type of Change

<!--- What types of changes does your code introduce? Put an `x` in all boxes that apply: -->

- [ ] 📱 New Feature (new page, component, or functionality)
- [ ] 🎨 UI/UX Update (visual changes, styling improvements)
- [ ] 📖 Content Update (text changes, documentation)
- [x] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [ ] ♿ Accessibility Enhancement
- [ ] 🔒 Security Update
- [ ] 📦 Dependency Update
- [ ] 🧹 Code Refactoring
- [ ] 🧪 Test Updates



### Before
https://github.com/user-attachments/assets/c5ddfef2-8470-4013-8e9c-9ff62968f99e

### After
https://github.com/user-attachments/assets/64ee4cdc-2652-46ec-8bc4-4de72afa46de

</details>





## 🧪 Testing Performed

### 📱 Browser Compatibility

<!--- Check all browsers where you've tested these changes -->

- [ ] Chrome (Version: )
- [ ] Firefox (Version: )
- [ ] Safari (Version: )
- [ ] Edge (Version: )
- [x] Mobile Chrome (Device: Tested on mobile device)
- [ ] Mobile Safari (Device: )

### 🖥️ Responsive Design

<!--- Confirm testing on different screen sizes -->

- [x] Desktop (1200px+) - Verified hover behavior still works
- [ ] Tablet (768px - 1199px)
- [x] Mobile (320px - 767px) - Verified touch pause functionality

### ✅ Test Cases

<!--- List the specific test cases you've verified -->

1. Desktop hover: Verified that hovering over testimonials pauses the marquee animation
2. Mobile touch: Verified that touching the testimonials on mobile pauses the animation
3. Mobile release: Verified that releasing touch resumes the animation
4. Build: Confirmed application builds successfully without errors
5. Code formatting: Verified code passes Prettier formatting checks

## ♿ Accessibility

<!--- Confirm accessibility requirements are met -->

- [x] Proper heading hierarchy maintained
- [x] ARIA labels added where needed (no changes to accessibility)
- [x] Color contrast requirements met
- [x] Keyboard navigation works correctly
- [x] Screen reader testing performed (no impact on screen readers)

## 📋 PR Checklist

<!--- Review and check all applicable items -->

- [x] My code follows the project's coding style guidelines
- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly (not needed - internal component fix)
- [x] My changes generate no new warnings or console errors
- [ ] I have added tests that prove my fix/feature works (manual testing performed)
- [ ] All existing tests pass successfully
- [x] I have checked for and resolved any merge conflicts
- [ ] I have optimized images/assets (if applicable) (N/A)
- [ ] I have validated all links are working correctly (N/A - no links changed)

## 💭 Additional Notes

<!--- Add any additional context, considerations, or notes for reviewers -->

**Changes made:**
- Added `useState` hook to track pause state for touch interactions
- Added `onTouchStart` handler to pause animation when user touches on mobile
- Added `onTouchEnd` handler to resume animation when user releases touch
- Desktop behavior unchanged - still uses CSS `group-hover` pseudo-class

**Technical details:**
- The fix uses React state to track touch interactions separately from hover
- CSS `group-hover` continues to work on desktop
- Touch events are handled via React event handlers for mobile compatibility
- Animation pause state is conditionally applied using Tailwind's `[animation-play-state:paused]` utility

**Testing evidence:**
- Recorded before/after videos demonstrating the fix on mobile devices
- Verified desktop hover behavior remains unaffected

---

### 📚 Reviewer Resources

- [Contributing Guide](https://github.com/sugarlabs/www-v2/blob/main/docs/CONTRIBUTING.md)
- [Style Guide](https://github.com/sugarlabs/www-v2/blob/main/docs/dev_guide.md)
- [Community Chat](https://matrix.to/#/#sugarlabs-web:matrix.org)

Thank you for contributing to the Sugar Labs website! 🎉




