### PR TITLE
Update view toggle button styles for dark mode

### DIFF
--- a/src/pages/News/TagPage.tsx
+++ b/src/pages/News/TagPage.tsx
@@ -301,13 +301,13 @@ const TagPage: React.FC = () => {
                       />
 
                       {/* View Toggle */}
-                      <div className="flex bg-gray-100 rounded-lg p-1">
+                      <div className="flex bg-gray-100 dark:bg-gray-700 rounded-lg p-1">
                         <button
                           onClick={() => setViewMode('grid')}
                           className={`p-2 rounded-md transition-colors ${
                             viewMode === 'grid'
-                              ? 'bg-white text-blue-600 shadow-sm'
-                              : 'text-gray-600'
+                              ? 'bg-white dark:bg-blue-600 dark:text-white text-blue-600 shadow-md'
+                              : 'text-gray-600 dark:text-gray-400 hover:text-blue-600'
                           }`}
                         >
                           <Grid className="w-4 h-4" />
@@ -316,8 +316,8 @@ const TagPage: React.FC = () => {
                           onClick={() => setViewMode('list')}
                           className={`p-2 rounded-md transition-colors ${
                             viewMode === 'list'
-                              ? 'bg-white text-blue-600 shadow-sm'
-                              : 'text-gray-600'
+                              ? 'bg-white dark:bg-blue-600 dark:text-white text-blue-600 shadow-md'
+                              : 'text-gray-600 dark:text-gray-400 hover:text-blue-600'
                           }`}
                         >
                           <List className="w-4 h-4" />


### PR DESCRIPTION

Fixes #805

## 📝 Description

Updated the view toggle button styles for the TagPage in dark mode to match the styling convention used elsewhere on the site. This ensures a consistent user experience across all pages in dark mode.



## 🔄 Type of Change

- [x] 🎨 UI/UX Update
- [x] 🐛 Bug Fix

## 📷 Visual Changes

<details>
<summary>Screenshots </summary>


<img width="732" height="523" alt="Screenshot 2026-01-26 223826" src="https://github.com/user-attachments/assets/770a1bbb-5ca3-4fdd-8d29-42c285bb3f10" />


<!-- Add before/after screenshots here -->

</details>

## 🧪 Testing

- [x] Tested in Chrome, Firefox, Safari, Edge
- [x] Responsive on desktop, tablet, and mobile
- [x] Color contrast and keyboard navigation verified

---

Thank you for contributing to the Sugar Labs website! 🎉