### PR TITLE
feat: error handling for the profiles fetch GitHub API

### DIFF
--- a/src/pages/Contributors.tsx
+++ b/src/pages/Contributors.tsx
@@ -41,7 +41,7 @@ interface Contributor {
 }
 
 const handleApiError = (
-  error: any,
+  error: unknown,
   context: 'repositories' | 'contributors',
 ) => {
   if (axios.isAxiosError(error)) {


### PR DESCRIPTION
## Summary -

While working recently at the `/profiles` route, I stumbled upon this section where I hit the rate limiter, and I saw an error message -  **"Failed to load contributors, please try again"**. I got completely clueless about the reason behind the message, because the message was not clear (I later realized it was related to me hitting the rate limiter of the GitHub API). It does the task well, but it hasn't been refined, and some additions were needed.

## Additions I did -

1. Made the UI a more refined look after getting the error
2. The error messages now tell clearly what the problem is (based on what the problem actually is)
3. I added the errors conditionally based on the API response to show what the user needs to see -
- If the API or the response is broken, then the user needs a **Try Again** button. I added that.
- If the User hits the rate limiter, then the **Try Again** button is pretty much useless, so I added the **Go to Homepage** button in that case.
4. Added separate states for repos and contributors both. Before, the same error message was shown for both repos and contributors, but now they show distinct messages.

**Note: the conditional rendering is being done purely based on the API responses and is dynamic**

## Visuals - 

### Before - 

**Dark mode**

<img width="1920" height="717" alt="image" src="https://github.com/user-attachments/assets/543e8a02-1e29-4243-a923-47535a2f5459" />

**Light mode**

<img width="1920" height="709" alt="image" src="https://github.com/user-attachments/assets/86ddacb6-f719-4edc-8635-c0fc09fe528a" />

### After

### When the request rate limiter is crossed

**Dark mode**

<img width="1920" height="745" alt="image" src="https://github.com/user-attachments/assets/032fdc9e-f6b6-4676-8946-8b826fad974e" />

**Light mode**

<img width="1919" height="745" alt="image" src="https://github.com/user-attachments/assets/8688ea18-cefd-47a9-bee7-ed09a0d8d4c7" />

### When the API is broken 

**Dark mode**

<img width="1919" height="756" alt="image" src="https://github.com/user-attachments/assets/b8f6e040-2a71-4c50-97a2-c1fac0a3af4a" />

**Light mode**

<img width="1920" height="729" alt="image" src="https://github.com/user-attachments/assets/11a40a3d-0d13-4434-8209-e008c9291b86" />




**If you want to check the error that comes when you hit the rate limiter, you can refer to the following snippet and put it inside any of the try blocks where the API is called**

```
const URL = "https://github-api-url-here";
const INTERVAL_MS = 100;

setInterval(async () => {
  try {
    await axios.get(URL);
    console.log("OK");

  } catch (err) {
    if (err.response?.status === 429) {
      console.log("RATE LIMITED");
    } else {
      console.log("API FAILURE", err.response?.status);
    }
  }
}, INTERVAL_MS);
```
### I have a few more implementations in my mind that we can add on top of this, so I just need the confirmations! For any suggestions, feel free to comment. Also, if this feels like a good change, we can move forward and make a few more changes like these to handle errors more gracefully throughout.

### Thanks!