### PR TITLE
Add detailed GSoC journey post on contributions and constructionism

### DIFF
--- a/src/constants/MarkdownFiles/posts/2026-03-29-gsoc-journey-contributions-and-constructionism.md
+++ b/src/constants/MarkdownFiles/posts/2026-03-29-gsoc-journey-contributions-and-constructionism.md
@@ -1,0 +1,608 @@
+---
+title: "My GSoC Journey at Sugar Labs: Contributions, Constructionism, and How My Thinking Changed"
+excerpt: "A personal long-form reflection on my Sugar Labs contribution journey, the work I shipped, the struggles I faced, and how constructionism changed how I learn."
+category: "DEVELOPER NEWS"
+date: "2026-03-29"
+slug: "2026-03-29-gsoc-journey-contributions-and-constructionism"
+author: "Ashutosh"
+description: "GSoC Contributor at SugarLabs"
+tags: "gsoc,sugarlabs,musicblocks,constructionism,seymour-papert,walter-bender,open-source"
+image: "assets/Images/GSOC.webp"
+---
+
+<!-- markdownlint-disable -->
+
+> "If you want to learn you need doing, and if you want to learn more you need more doing."  
+> — Walter Bender
+
+# My GSoC Journey at Sugar Labs: Contributions, Constructionism, and How My Thinking Changed
+
+I started this journey with a simple idea in my head: if I contribute enough code, I will become better.
+
+That was partially true.
+
+What I did not expect was that contributing to Sugar Labs would reshape how I think about engineering, learning, community, and responsibility. I thought I was entering a codebase. In reality, I entered a philosophy in action.
+
+That philosophy is constructionism: learning by making meaningful things, reflecting on them, and improving them with others. The more I contributed, the more this became real in my day-to-day engineering practice.
+
+This is my longer, honest, personal reflection on that journey.
+
+---
+
+## Where I Started
+
+In the beginning, I measured progress in a very narrow way:
+
+- number of PRs opened,
+- number of lines changed,
+- number of merges.
+
+That metric gave me early motivation, but it was incomplete. It did not capture quality, long-term maintainability, user trust, or the learning loop happening through reviews.
+
+As my contribution volume grew, my perspective changed from:
+
+- "How fast can I submit?"
+
+to:
+
+- "How deeply do I understand the system I am changing?"
+
+That one shift changed everything.
+
+---
+
+## Contribution Snapshot (as of February 25, 2026)
+
+- **Repositories:** 2
+- **Total PRs:** 75
+- **Merged PRs:** 44
+- **Open PRs:** 19
+- **Closed PRs:** 8
+
+### Repository Distribution
+
+- **sugarlabs/musicblocks**: 60 PRs
+- **sugarlabs/www-v2**: 2 PRs
+
+These numbers are not the story by themselves, but they are the map of where my time, curiosity, and effort went.
+
+---
+
+## Contribution Depth Map: What I Actually Contributed
+
+To make this journey concrete, I mapped my work by contribution type instead of just timeline.
+
+### Reliability and Bug-Fix Contributions
+
+These contributions focused on crash prevention, safer initialization, edge-case handling, and runtime resilience.
+
+- [#5550](https://github.com/sugarlabs/musicblocks/pull/5550) - Fix dev mode hot reload
+- [#5642](https://github.com/sugarlabs/musicblocks/pull/5642) - Resolve initialization crashes and loading screen issues
+- [#5677](https://github.com/sugarlabs/musicblocks/pull/5677) - Prevent crashes on hidden/zero viewport states
+- [#5679](https://github.com/sugarlabs/musicblocks/pull/5679) - Address critical bugs in core utilities and singer logic
+- [#5428](https://github.com/sugarlabs/musicblocks/pull/5428) - Fix piemenu pitch selection
+- [#5338](https://github.com/sugarlabs/musicblocks/pull/5338) - Fix setTimeout bugs
+- [#5337](https://github.com/sugarlabs/musicblocks/pull/5337) - Replace Firefox delay with readiness-based init
+- [#5300](https://github.com/sugarlabs/musicblocks/pull/5300) - Load p5-sound-adapter correctly
+- [#5052](https://github.com/sugarlabs/musicblocks/pull/5052) - Fix operator-precedence bug
+- [#5046](https://github.com/sugarlabs/musicblocks/pull/5046) - Fix race condition in connection store lock
+
+### Performance and Memory Contributions
+
+These contributions targeted rendering smoothness, memory usage, interaction latency, and algorithmic efficiency.
+
+- [#5458](https://github.com/sugarlabs/musicblocks/pull/5458) - Widget performance optimization with Set + RAF throttling
+- [#5929](https://github.com/sugarlabs/musicblocks/pull/5929) - Save ~70-120 MB via lazy-cached grid bitmaps + scroll-canvas shrink
+- [#5928](https://github.com/sugarlabs/musicblocks/pull/5928) - Save ~50-115 MB by disposing leaked Tone.js synths
+- [#5801](https://github.com/sugarlabs/musicblocks/pull/5801) - Optimize block drag interactions
+- [#5457](https://github.com/sugarlabs/musicblocks/pull/5457) - Cache DOM element references
+- [#5456](https://github.com/sugarlabs/musicblocks/pull/5456) - Performance optimizations for block operations
+- [#5455](https://github.com/sugarlabs/musicblocks/pull/5455) - Cache getTurtleCount() in loops
+- [#5304](https://github.com/sugarlabs/musicblocks/pull/5304) - Optimize blockList iteration with for...of
+- [#5239](https://github.com/sugarlabs/musicblocks/pull/5239) - Cache rationalToFraction in frequency loop
+- [#5238](https://github.com/sugarlabs/musicblocks/pull/5238) - Cache interval-to-note calls
+- [#5161](https://github.com/sugarlabs/musicblocks/pull/5161) - Optimize canvas rendering
+- [#5091](https://github.com/sugarlabs/musicblocks/pull/5091) - Dirty-flag pattern for canvas rendering
+- [#5022](https://github.com/sugarlabs/musicblocks/pull/5022) - Lazy loading for audio samples
+
+### Testing and Quality Contributions
+
+These contributions improved confidence, prevented regressions, and made system behavior explicit.
+
+- [#5101](https://github.com/sugarlabs/musicblocks/pull/5101) - Tempo test coverage increase (6 to 40 tests)
+- [#5084](https://github.com/sugarlabs/musicblocks/pull/5084) - ModeWidget unit tests
+- [#5082](https://github.com/sugarlabs/musicblocks/pull/5082) - MeterWidget unit tests
+- [#5059](https://github.com/sugarlabs/musicblocks/pull/5059) - MathUtility edge-case tests
+- [#5037](https://github.com/sugarlabs/musicblocks/pull/5037) - Unit tests for piemenus.js
+- [#5033](https://github.com/sugarlabs/musicblocks/pull/5033) - Unit tests for loader.js
+- [#5002](https://github.com/sugarlabs/musicblocks/pull/5002) - Tests for logo.js and palette
+
+### Modernization, Refactor, and Maintainability Contributions
+
+These contributions reduced technical debt and made code easier to reason about and extend.
+
+- [#5454](https://github.com/sugarlabs/musicblocks/pull/5454) - Convert sync XHR to async fetch API
+- [#5466](https://github.com/sugarlabs/musicblocks/pull/5466) - Mark locale JSON files as generated
+- [#5065](https://github.com/sugarlabs/musicblocks/pull/5065) - Cleanup FIXME comments
+- [#5051](https://github.com/sugarlabs/musicblocks/pull/5051) - Replace var with let/const
+- [#5038](https://github.com/sugarlabs/musicblocks/pull/5038) - Remove unused variables and eslint-disable
+
+### CI/CD and Website Contributions
+
+These contributions improved engineering workflows and frontend performance across Sugar Labs properties.
+
+- [#5318](https://github.com/sugarlabs/musicblocks/pull/5318) - Add Lighthouse CI
+- [#6062](https://github.com/sugarlabs/musicblocks/pull/6062) - Add PR category to CI/CD workflow
+- [#717](https://github.com/sugarlabs/www-v2/pull/717) - Website performance optimization + SEO metadata
+- [#760](https://github.com/sugarlabs/www-v2/pull/760) - Fix dark mode lag and transition bottlenecks
+
+### Active Open Contribution Threads
+
+These are areas where my contribution is still ongoing and not treated as "done".
+
+- [#5870](https://github.com/sugarlabs/musicblocks/pull/5870) - MIDI upload widget
+- [#5855](https://github.com/sugarlabs/musicblocks/pull/5855) - Bounded exponential backoff for retries
+- [#5799](https://github.com/sugarlabs/musicblocks/pull/5799) - Replace raw setTimeout calls with ManagedTimer
+- [#5798](https://github.com/sugarlabs/musicblocks/pull/5798) - Replace O(N) blockList lookups with O(1) blockIndex
+- [#5930](https://github.com/sugarlabs/musicblocks/pull/5930) - Defer p5/Chart loading + fix DOM listener leak
+- [#5797](https://github.com/sugarlabs/musicblocks/pull/5797) - Defer checkBounds during batch operations
+- [#5643](https://github.com/sugarlabs/musicblocks/pull/5643) - Improve code quality and robustness
+- [#5612](https://github.com/sugarlabs/musicblocks/pull/5612) - Intervals palette tests
+- [#5611](https://github.com/sugarlabs/musicblocks/pull/5611) - Pitch palette advanced tests
+- [#5610](https://github.com/sugarlabs/musicblocks/pull/5610) - Rhythm palette advanced tests
+- [#5608](https://github.com/sugarlabs/musicblocks/pull/5608) - Rhythm palette beginner tests
+- [#5502](https://github.com/sugarlabs/musicblocks/pull/5502) - Phase 3: Version Control WF2
+- [#5496](https://github.com/sugarlabs/musicblocks/pull/5496) - Phase 2: Cloud sync and conflict resolution
+- [#5126](https://github.com/sugarlabs/musicblocks/pull/5126) - Interactive first project tutorial
+- [#830](https://github.com/sugarlabs/www-v2/pull/830) - Join development landing page
+
+---
+
+## Contribution Case Studies (Before -> After)
+
+To emphasize contribution depth, here are concrete patterns from my work where changes had visible system-level effect.
+
+### Case Study 1: Memory Pressure Reduction in Real Sessions
+
+Before:
+
+- Long sessions accumulated unnecessary memory usage and created degradation risk.
+
+After:
+
+- [#5929](https://github.com/sugarlabs/musicblocks/pull/5929) and [#5928](https://github.com/sugarlabs/musicblocks/pull/5928) targeted two different memory paths, reducing usage by tens of MB in practical conditions.
+
+Why this mattered:
+
+- Educational sessions are often long-running and exploratory. Lower memory pressure means fewer crashes, better responsiveness, and stronger trust.
+
+### Case Study 2: Input Interaction and Creative Flow
+
+Before:
+
+- Interaction pathways such as drag behavior could feel heavy under load.
+
+After:
+
+- [#5801](https://github.com/sugarlabs/musicblocks/pull/5801), [#5458](https://github.com/sugarlabs/musicblocks/pull/5458), and [#5091](https://github.com/sugarlabs/musicblocks/pull/5091) improved interaction responsiveness and rendering discipline.
+
+Why this mattered:
+
+- In creative tools, interaction latency directly affects learner momentum and confidence.
+
+### Case Study 3: Reliability Under Non-Ideal Runtime States
+
+Before:
+
+- Hidden tabs, viewport edge states, and startup timing created fragile behavior.
+
+After:
+
+- [#5642](https://github.com/sugarlabs/musicblocks/pull/5642), [#5677](https://github.com/sugarlabs/musicblocks/pull/5677), and [#5550](https://github.com/sugarlabs/musicblocks/pull/5550) strengthened startup/runtime safety.
+
+Why this mattered:
+
+- School and lab environments are messy in practice. Software must be robust in imperfect contexts.
+
+### Case Study 4: Test Depth as Contribution Multiplier
+
+Before:
+
+- Several behavior zones lacked strong safety nets for future changes.
+
+After:
+
+- The test series around tempo, widgets, math utilities, and loaders improved confidence for maintainers and contributors.
+
+Why this mattered:
+
+- Good tests turn one contribution into a long-term regression shield for many contributors.
+
+---
+
+## How Specific PRs Trained My Constructionist Thinking
+
+One of the biggest lessons from this journey is that constructionism was not only in theory sections or references. It was built directly through PR work.
+
+Below is how specific contribution clusters shaped my constructionist learning.
+
+### 1. Learning Through Concrete Artifact-Building
+
+Constructionism starts with making meaningful artifacts. For me, these were not toy patches, but production-facing improvements:
+
+- [#5929](https://github.com/sugarlabs/musicblocks/pull/5929) and [#5928](https://github.com/sugarlabs/musicblocks/pull/5928) taught me to turn memory analysis into real architectural changes.
+- [#5801](https://github.com/sugarlabs/musicblocks/pull/5801) and [#5458](https://github.com/sugarlabs/musicblocks/pull/5458) taught me to convert interaction pain into measurable rendering improvements.
+- [#5642](https://github.com/sugarlabs/musicblocks/pull/5642) and [#5677](https://github.com/sugarlabs/musicblocks/pull/5677) taught me to design for non-ideal runtime conditions, not ideal demos.
+
+How this helped my constructionism:
+
+- I learned that understanding grows when I build something that others can use, test, and challenge.
+- I stopped treating contribution as task completion and started treating it as artifact design.
+
+### 2. Learning Through Reflection and Feedback Loops
+
+Constructionism is not only making; it is making plus reflection. PR review became that reflection engine.
+
+- Reliability PRs like [#5550](https://github.com/sugarlabs/musicblocks/pull/5550) and [#5679](https://github.com/sugarlabs/musicblocks/pull/5679) forced me to revisit assumptions after review and reproduction feedback.
+- Refactor/modernization PRs like [#5454](https://github.com/sugarlabs/musicblocks/pull/5454) and [#5051](https://github.com/sugarlabs/musicblocks/pull/5051) showed me that "cleaner code" is meaningful only when maintainers can reason about it faster.
+
+How this helped my constructionism:
+
+- I learned to treat feedback as part of the artifact, not criticism of the person.
+- I learned that revision is not rework; revision is where learning becomes visible.
+
+### 3. Learning Through Public, Shareable Knowledge
+
+A core constructionist idea is that learning deepens when the created artifact is socially shareable.
+
+- Testing PRs [#5101](https://github.com/sugarlabs/musicblocks/pull/5101), [#5084](https://github.com/sugarlabs/musicblocks/pull/5084), [#5082](https://github.com/sugarlabs/musicblocks/pull/5082), and [#5059](https://github.com/sugarlabs/musicblocks/pull/5059) transformed private understanding into public, executable knowledge.
+- CI/workflow PRs [#5318](https://github.com/sugarlabs/musicblocks/pull/5318) and [#6062](https://github.com/sugarlabs/musicblocks/pull/6062) made quality expectations visible and repeatable for everyone.
+
+How this helped my constructionism:
+
+- I learned to convert "I know this behavior" into "the project now knows this behavior."
+- I learned that a test suite is a social memory system for the contributor community.
+
+### 4. Learning Through Identity Shift: From Coder to Contributor
+
+Constructionism also changes identity. You move from solving your own problem to improving shared learning conditions.
+
+- Website PRs [#717](https://github.com/sugarlabs/www-v2/pull/717) and [#760](https://github.com/sugarlabs/www-v2/pull/760) reminded me that contribution quality includes UX, accessibility, and performance at the community entry layer.
+- Open PR streams like [#5855](https://github.com/sugarlabs/musicblocks/pull/5855), [#5799](https://github.com/sugarlabs/musicblocks/pull/5799), [#5798](https://github.com/sugarlabs/musicblocks/pull/5798), and [#5126](https://github.com/sugarlabs/musicblocks/pull/5126) keep me in a long-cycle learning mode where iteration itself is the pedagogy.
+
+How this helped my constructionism:
+
+- I learned to evaluate success by what future contributors can build more easily because of my work.
+- I learned that contribution is a learning relationship, not a one-time code drop.
+
+### My Constructionist Formula from PR Practice
+
+If I compress this into one working formula from my own PR journey:
+
+1. Build a meaningful change.
+2. Expose it to critique.
+3. Revise with evidence.
+4. Encode learning in tests/docs/workflows.
+5. Leave the project easier for the next contributor.
+
+That cycle is where most of my real growth happened.
+
+---
+
+## The Real Journey Behind Those PRs
+
+### Phase 1: Learning to Observe Before Touching Code
+
+My early instinct was to jump straight to a fix. Over time, I realized that many bugs are symptoms, not root causes.
+
+I began spending more time reproducing issues carefully, checking browser/state conditions, and understanding where assumptions were breaking.
+
+This changed how I approached reliability-related work such as:
+
+- [#5550](https://github.com/sugarlabs/musicblocks/pull/5550) - Fix dev mode hot reload
+- [#5642](https://github.com/sugarlabs/musicblocks/pull/5642) - Resolve initialization crashes and loading-screen issues
+- [#5677](https://github.com/sugarlabs/musicblocks/pull/5677) - Prevent crashes on hidden/zero viewport states
+- [#5679](https://github.com/sugarlabs/musicblocks/pull/5679) - Address critical bugs in core utilities and singer logic
+- [#5046](https://github.com/sugarlabs/musicblocks/pull/5046) - Fix race condition in connection store lock
+
+I learned that when users report "it crashed," they are really telling us: "the product broke trust with me."
+
+### Phase 2: Performance Work That Changed My Engineering Habits
+
+Performance started as a technical interest. It turned into a discipline.
+
+When I worked on rendering and memory-heavy paths, I became more intentional about lifecycle ownership, disposal, caching boundaries, and event-listener hygiene.
+
+Representative work:
+
+- [#5458](https://github.com/sugarlabs/musicblocks/pull/5458) - Optimize widget performance (`Set` + RAF throttling)
+- [#5929](https://github.com/sugarlabs/musicblocks/pull/5929) - Save ~70-120 MB via lazy-cached grid bitmaps + scroll-canvas shrink
+- [#5928](https://github.com/sugarlabs/musicblocks/pull/5928) - Save ~50-115 MB by disposing leaked Tone.js synths
+- [#5801](https://github.com/sugarlabs/musicblocks/pull/5801) - Optimize block drag interactions
+- [#5161](https://github.com/sugarlabs/musicblocks/pull/5161), [#5091](https://github.com/sugarlabs/musicblocks/pull/5091) - Canvas optimization and dirty-flag rendering pattern
+
+This work made me understand something deeply:
+
+- Performance is not about benchmarks only.
+- Performance is about preserving flow for learners creating music.
+
+A laggy interface interrupts thought. A smooth interface supports creativity.
+
+### Phase 3: Testing as a Thinking Tool, Not a Formality
+
+At first, writing tests felt like "extra work after coding." Then it became the place where my thinking matured.
+
+Tests forced me to define behavior clearly, especially in edge cases where implicit assumptions usually hide.
+
+Representative testing contributions:
+
+- [#5101](https://github.com/sugarlabs/musicblocks/pull/5101) - Increase tempo test coverage (6 to 40 tests)
+- [#5084](https://github.com/sugarlabs/musicblocks/pull/5084) - ModeWidget unit tests
+- [#5082](https://github.com/sugarlabs/musicblocks/pull/5082) - MeterWidget unit tests
+- [#5059](https://github.com/sugarlabs/musicblocks/pull/5059) - MathUtility edge-case tests
+- [#5037](https://github.com/sugarlabs/musicblocks/pull/5037), [#5033](https://github.com/sugarlabs/musicblocks/pull/5033), [#5002](https://github.com/sugarlabs/musicblocks/pull/5002) - Tests for piemenus, loader, logo, and palette
+
+Today, I see tests as a communication artifact: they explain expected behavior to future contributors more clearly than comments often can.
+
+### Phase 4: Quality Beyond the Product Surface
+
+I also contributed to CI/tooling and website performance work:
+
+- [#5318](https://github.com/sugarlabs/musicblocks/pull/5318) - Add Lighthouse CI
+- [#6062](https://github.com/sugarlabs/musicblocks/pull/6062) - Add PR category support in CI/CD
+- [#717](https://github.com/sugarlabs/www-v2/pull/717) - Performance optimization + SEO metadata
+- [#760](https://github.com/sugarlabs/www-v2/pull/760) - Fix dark mode lag and transition bottlenecks
+
+This phase taught me that contribution is ecosystem work:
+
+- product behavior,
+- developer workflows,
+- delivery confidence.
+
+All three matter.
+
+---
+
+## Personal Struggles I Faced (And What They Taught Me)
+
+I want this post to be honest, not only celebratory.
+
+### 1. The pressure to always be "productive"
+
+When your contribution graph is visible, it is easy to optimize for visible activity instead of deep work. I had to consciously move away from that.
+
+Lesson:
+
+- One well-understood fix is often more valuable than multiple shallow patches.
+
+### 2. Balancing ambition with maintainability
+
+Sometimes I wanted to "improve everything" in one PR. Reviews and experience taught me to scope changes in maintainable slices.
+
+Lesson:
+
+- Small, coherent, reviewable changes improve merge quality and team trust.
+
+### 3. Learning to accept iterative feedback
+
+Receiving review feedback is easy when it confirms your approach, and harder when it challenges design decisions.
+
+Lesson:
+
+- Feedback is not rejection; it is collaborative problem-solving.
+
+### 4. Avoiding tunnel vision
+
+Working deeply in one subsystem can make you forget broader product behavior.
+
+Lesson:
+
+- Always validate local optimizations against global user experience.
+
+---
+
+## Constructionism: The Philosophy That Made Sense of My Experience
+
+The most important intellectual shift in my journey came from understanding constructionism more seriously.
+
+Constructionism, associated with Seymour Papert, argues that learners build knowledge most effectively when they actively create meaningful artifacts and reflect on the process.
+
+At Sugar Labs, this is not abstract theory. It is operational.
+
+In my experience, there are three layers to it:
+
+- **Artifact layer:** You build something concrete (a fix, feature, test suite, benchmark, documentation patch).
+- **Reflection layer:** You inspect behavior, receive critique, revise assumptions, and improve the artifact.
+- **Community layer:** The artifact becomes part of shared infrastructure that others reuse, review, and extend.
+
+That is where contribution becomes learning, and learning becomes contribution.
+
+## From Constructionism to Contributism (How I Understood It Personally)
+
+I use the word "contributism" to describe constructionism in open-source practice: learning by making public contributions that are reviewed, revised, and carried forward by a community.
+
+This helped me separate three very different activities:
+
+- **Coding privately:** useful for skill-building, but limited feedback and limited social impact.
+- **Shipping quickly:** useful for momentum, but may not create durable knowledge.
+- **Contributing constructively:** slower at first, but compounds learning and impact over time.
+
+In this model, a PR is not just a delivery unit. It is a learning unit.
+
+### The Contributist Loop I Repeated
+
+Across dozens of PRs, I found myself repeating the same loop:
+
+1. **Notice a real friction point**  
+   A crash, lag, memory leak, flaky behavior, or unclear logic.
+2. **Model the system**  
+   Reproduce carefully, isolate assumptions, map lifecycle/timing boundaries.
+3. **Build a bounded intervention**  
+   Implement one coherent change with clear scope.
+4. **Open for critique**  
+   Get review feedback from maintainers and peers.
+5. **Refine and reframe**  
+   Update code, tests, naming, abstractions, and sometimes the original hypothesis.
+6. **Leave reusable knowledge behind**  
+   Through tests, commit history, clearer architecture, and issue/PR context.
+
+This is why contribution changed my thinking more than isolated coding ever did.
+
+### What This Changed in Me
+
+The deeper effect was not only technical growth. It was epistemic growth: how I decide what is true about a system.
+
+- I moved from "works for me" to "works across conditions."
+- I moved from "fix this line" to "stabilize this behavior."
+- I moved from "my solution" to "our maintainable direction."
+
+The best example is performance work. Initially, I treated performance as optimization. Over time, I treated it as pedagogy.
+
+If a learner drags a block and the UI stutters, the learner is not thinking about graphics pipelines. They are deciding whether to continue creating or stop. That makes performance an educational concern, not a cosmetic one.
+
+The same is true for reliability. A crash is not just an exception trace. It is a broken trust moment. Fixing reliability is restoring that trust.
+
+### Why Contribution Depth Matters More Than Contribution Volume
+
+I still value contribution counts because they show consistency, but depth matters more:
+
+- Did the change reduce recurring classes of bugs?
+- Did it improve reviewability and future maintenance?
+- Did it add tests that prevent regressions?
+- Did it make the system easier for the next contributor to understand?
+
+When I look back at my own work, the PRs I value most are not always the biggest. They are the ones that improved the system's long-term behavior and contributor experience.
+
+That, to me, is contributism in practice: not just adding code, but improving the conditions under which people learn, build, and collaborate.
+
+---
+
+## Papert -> OLPC -> Walter Bender -> Sugar Labs
+
+This lineage helped me understand why Sugar Labs feels different from many other open-source spaces.
+
+### Seymour Papert
+
+Papert's educational vision centered on active, creative, computational learning rather than passive instruction.
+
+### One Laptop per Child (OLPC)
+
+OLPC attempted to bring this vision to scale by giving children tools for creation and exploration.
+
+### Walter Bender
+
+Walter Bender led software/content in OLPC and oversaw Sugar UI development. After the 2008 strategic split at OLPC, he founded Sugar Labs so Sugar could continue independently as a community-driven free-software learning platform.
+
+For me as a contributor, this context matters. It means contribution here is not only about feature velocity. It is also about protecting an educational mission.
+
+---
+
+## How Constructionism Changed My Day-to-Day Engineering Thinking
+
+### From "does this work?" to "what does this help others learn?"
+
+I now evaluate code not only by correctness, but by readability, testability, and future extensibility.
+
+### From "my patch" to "shared artifact"
+
+A merged PR is not a private achievement. It becomes shared infrastructure for the community.
+
+### From "fixing bugs" to "designing better learning conditions"
+
+In educational software, stability and responsiveness are pedagogical concerns. They influence whether a learner continues exploring or gives up.
+
+### From "individual speed" to "collective momentum"
+
+I now care more about whether my work increases overall contributor throughput: better tests, clearer abstractions, safer defaults, and fewer regressions.
+
+---
+
+## Ongoing Threads and What I Want to Improve Next
+
+Some active contribution directions:
+
+- [#5870](https://github.com/sugarlabs/musicblocks/pull/5870) - MIDI upload widget
+- [#5855](https://github.com/sugarlabs/musicblocks/pull/5855) - Bounded exponential backoff for retries
+- [#5799](https://github.com/sugarlabs/musicblocks/pull/5799) - Managed timer migration
+- [#5798](https://github.com/sugarlabs/musicblocks/pull/5798) - O(1) block index lookup path
+- [#5930](https://github.com/sugarlabs/musicblocks/pull/5930) - Deferred p5/Chart loading + listener leak fix
+- [#5126](https://github.com/sugarlabs/musicblocks/pull/5126) - Interactive first project tutorial
+- [#830](https://github.com/sugarlabs/www-v2/pull/830) - Join development landing page
+
+My next personal goals are intentionally constructionist:
+
+- improve how I design and document architectural changes, so each PR is also a reusable learning artifact for future contributors,
+- deepen test strategy for long-lived interaction flows, so behavioral knowledge is preserved in executable form,
+- keep contribution quality high without losing iteration speed, by scoping work into small reflection-friendly cycles,
+- mentor newer contributors through clearer review and context-sharing, so learning happens collaboratively and not in isolation.
+
+I also want to propose a more explicit constructionist contribution model for my future work:
+
+- each major PR should include a short "what I learned" and "what future contributors should watch for" note,
+- each bug-fix PR should include at least one regression-focused test whenever feasible,
+- each performance PR should include before/after reasoning (what changed, why it matters for learners, and what tradeoff was accepted),
+- each contributor-facing feature should reduce onboarding friction for the next person who wants to build.
+
+If constructionism means learning by making meaningful things, then my proposal is simple: make every contribution meaningful for both users and future contributors.
+
+---
+
+## Final Reflection
+
+If I had to summarize this journey in one line, it would be:
+
+**I came to Sugar Labs to contribute code, but stayed to learn how to build learning systems with people.**
+
+That is the deepest impact this journey had on me.
+
+Constructionism is no longer just a concept I cite. It is now the way I practice engineering:
+
+- build,
+- test,
+- reflect,
+- revise,
+- share.
+
+And then do it again, better.
+
+---
+
+## References
+
+### Core theory and history
+
+1. Constructionism (learning theory) - Wikipedia  
+   https://en.wikipedia.org/wiki/Constructionism_(learning_theory)
+2. Seymour Papert - Wikipedia  
+   https://en.wikipedia.org/wiki/Seymour_Papert
+3. One Laptop per Child - Wikipedia  
+   https://en.wikipedia.org/wiki/One_Laptop_per_Child
+
+### Walter Bender and Sugar continuity
+
+4. Walter Bender - Wikipedia  
+   https://en.wikipedia.org/wiki/Walter_Bender
+5. OLPC software split and Sugar Labs launch (Ars Technica, 2008)  
+   https://arstechnica.com/information-technology/2008/05/former-olpc-software-president-wants-to-expand-sugars-reach/
+6. Bender launches Sugar Labs (Computerworld, 2008)  
+   https://www.computerworld.com/article/1395190/bender-launches-sugar-labs-to-promote-olpc-s-ui.html
+
+### Walter Bender video references
+
+7. Sugar Labs presentation index (includes Walter Bender talks)  
+   https://wiki.sugarlabs.org/go/How_to_present_Sugar
+8. "Beyond Open Source" - Walter Bender (YouTube)  
+   https://www.youtube.com/watch?v=xnjBiZCD1gs
+9. Walter Bender at World NetBook Summit (YouTube)  
+   https://www.youtube.com/watch?v=1pynzS5F50Y
+10. "Program or be programmed" - Walter Bender (YouTube)  
+    https://www.youtube.com/watch?v=5bUYtgLhAfo
+
+### User-provided archival links
+
+11. Why Walter Bender left OLPC (NYT archive link provided by user)  
+    https://archive.nytimes.com/bits.blogs.nytimes.com/2008/05/27/why-walter-bender-left-one-laptop-per-child-edited-hold-for-wed-am/
+12. "Untangling free, sugar and ..." (Bill Kerr blog link provided by user)  
+    https://billkerr2.blogspot.com/2008/06/untangling-free-sugar-and.html
+
+Note: I could not reliably fetch content from links 11 and 12 in this environment, so I did not quote them directly.


### PR DESCRIPTION
## Summary

This PR adds a new long-form Developer News blog post documenting my GSoC journey at Sugar Labs, with a strong focus on:

- contribution impact across reliability, performance, testing, and CI/CD
- constructionism as the learning framework behind my contribution process
- PR-to-learning mapping (how specific contributions shaped my engineering thinking)

## Added

- `src/constants/MarkdownFiles/posts/2026-03-29-gsoc-journey-contributions-and-constructionism.md`

## What The Blog Covers

- personal journey narrative (motivation, growth, struggles, reflection)
- contribution depth map by category:
  - reliability and bug fixes
  - performance and memory optimization
  - testing and quality
  - modernization/refactors
  - CI/CD and website contributions
- case studies with before/after impact framing
- constructionism-focused sections:
  - constructionism in practice through open-source contribution
  - contributist loop (build -> review -> revise -> codify -> share)
  - how specific PRs contributed to learning, not just delivery
- references to Papert, OLPC, Walter Bender, and supporting resources

## Why This Is Useful

- provides transparent, evidence-backed reflection of contribution work
- connects engineering practice with Sugar Labs' educational philosophy
- creates a reusable narrative model for future contributor journey posts

## Notes

- This PR introduces one new markdown blog file only.
- No code/runtime behavior changes are included.
