### PR TITLE
fix: resolve logo path for nested routes

### DIFF
--- a/src/sections/Header.tsx
+++ b/src/sections/Header.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
-import logo from '/assets/Icons/logo.svg';
+const logo = `${import.meta.env.BASE_URL}assets/Icons/logo.svg`;
 import NavDropdown from '@/sections/NavDropdown';
 import { navigationData } from '@/constants/Header';
 import DarkModeToggle from '@/components/shared/DarkModeToggle';

--- a/src/sections/Header.tsx
+++ b/src/sections/Header.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
-const logo = `${import.meta.env.BASE_URL}assets/Icons/logo.svg`;
 import NavDropdown from '@/sections/NavDropdown';
 import { navigationData } from '@/constants/Header';
 import DarkModeToggle from '@/components/shared/DarkModeToggle';
+
+const LOGO_PATH = '/assets/Icons/logo.svg';
 
 const Header: React.FC = () => {
   const location = useLocation();
@@ -80,7 +81,7 @@ const Header: React.FC = () => {
               onClick={handleNavigation}
             >
               <img
-                src={logo}
+                src={LOGO_PATH}
                 alt="Sugar Labs"
                 className="h-8 md:h-12 w-auto transition-transform hover:scale-105"
               />


### PR DESCRIPTION
## Summary
Fixes the navbar logo not displaying on activity pages (routes like `/app/...`).

Fixes #832

## Problem
The logo was imported using Vite's asset import:
```typescript
import logo from '/assets/Icons/logo.svg';
```

With `base: './'` in vite.config.ts, Vite transforms this to a relative path (`./assets/Icons/logo.svg`). On nested routes like `/app/org.sugarlabs.RecallActivity.html`, the browser resolves this relative path incorrectly to `/app/assets/Icons/logo.svg` instead of `/assets/Icons/logo.svg`.

## Solution
Use a hardcoded absolute path string instead of an import:
```typescript
const LOGO_PATH = '/assets/Icons/logo.svg';
```

This path:
- Is **not** processed by Vite's asset transformation
- Always resolves from the domain root regardless of current route
- Works correctly because the site is deployed at domain root (`v4.activities.sugarlabs.org/`)

## Why NOT `import.meta.env.BASE_URL`?
With `base: './'`, `import.meta.env.BASE_URL` equals `./`. So:
```typescript
const logo = `${import.meta.env.BASE_URL}assets/Icons/logo.svg`;
// Results in: ./assets/Icons/logo.svg
```
On `/app/page.html`, this **still** resolves to `/app/assets/Icons/logo.svg` — the same broken behavior.

## Testing
- Logo displays correctly on main pages
- Logo displays correctly on nested routes like `/app/...`