### PR TITLE
fix: scroll to articles section on pagination instead of page top

### DIFF
--- a/src/pages/News/AuthorPage.tsx
+++ b/src/pages/News/AuthorPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -39,6 +39,7 @@ const AuthorPage: React.FC = () => {
 
   // UI State
   const [currentPage, setCurrentPage] = useState(1);
+  const articlesRef = useRef<HTMLDivElement>(null);
   const itemsPerPage = 6;
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('All');
@@ -123,7 +124,14 @@ const AuthorPage: React.FC = () => {
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    if (articlesRef.current) {
+      const navbarOffset = 80;
+      const top =
+        articlesRef.current.getBoundingClientRect().top +
+        window.scrollY -
+        navbarOffset;
+      window.scrollTo({ top, behavior: 'smooth' });
+    }
   };
 
   const getUniqueCategories = () => {
@@ -292,7 +300,7 @@ const AuthorPage: React.FC = () => {
               )}
 
               {/* Articles Section */}
-              <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl dark:shadow-2xl dark:shadow-black/20 p-4 sm:p-6 lg:p-8">
+              <div ref={articlesRef} className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl dark:shadow-2xl dark:shadow-black/20 p-4 sm:p-6 lg:p-8">
                 <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
                   <div className="flex items-center gap-2">
                     <BookOpen className="w-5 h-5 text-blue-600 dark:text-blue-400" />

--- a/src/pages/News/AuthorPage.tsx
+++ b/src/pages/News/AuthorPage.tsx
@@ -300,7 +300,10 @@ const AuthorPage: React.FC = () => {
               )}
 
               {/* Articles Section */}
-              <div ref={articlesRef} className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl dark:shadow-2xl dark:shadow-black/20 p-4 sm:p-6 lg:p-8">
+              <div
+                ref={articlesRef}
+                className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl dark:shadow-2xl dark:shadow-black/20 p-4 sm:p-6 lg:p-8"
+              >
                 <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
                   <div className="flex items-center gap-2">
                     <BookOpen className="w-5 h-5 text-blue-600 dark:text-blue-400" />

--- a/src/pages/News/AuthorPage.tsx
+++ b/src/pages/News/AuthorPage.tsx
@@ -124,14 +124,7 @@ const AuthorPage: React.FC = () => {
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
-    if (articlesRef.current) {
-      const navbarOffset = 80;
-      const top =
-        articlesRef.current.getBoundingClientRect().top +
-        window.scrollY -
-        navbarOffset;
-      window.scrollTo({ top, behavior: 'smooth' });
-    }
+    articlesRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 
   const getUniqueCategories = () => {
@@ -302,7 +295,7 @@ const AuthorPage: React.FC = () => {
               {/* Articles Section */}
               <div
                 ref={articlesRef}
-                className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl dark:shadow-2xl dark:shadow-black/20 p-4 sm:p-6 lg:p-8"
+                className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl dark:shadow-2xl dark:shadow-black/20 p-4 sm:p-6 lg:p-8 scroll-mt-16 md:scroll-mt-20"
               >
                 <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
                   <div className="flex items-center gap-2">

--- a/src/pages/News/NewsPage.tsx
+++ b/src/pages/News/NewsPage.tsx
@@ -173,7 +173,10 @@ const NewsPage: React.FC = () => {
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
     if (articlesRef.current) {
-      articlesRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      articlesRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
     }
   };
 

--- a/src/pages/News/NewsPage.tsx
+++ b/src/pages/News/NewsPage.tsx
@@ -284,7 +284,10 @@ const NewsPage: React.FC = () => {
             </div>
           </div>
 
-          <div ref={articlesRef} className="container mx-auto px-4 py-8">
+          <div
+            ref={articlesRef}
+            className="container mx-auto px-4 py-8 scroll-mt-16 md:scroll-mt-20"
+          >
             {/* Enhanced Filters and Controls */}
             <div className="bg-white dark:bg-gray-800/50 dark:backdrop-blur-sm rounded-2xl shadow-xl p-6 mb-8 border border-gray-100 dark:border-gray-700">
               <div className="flex flex-col lg:flex-row gap-6">

--- a/src/pages/News/NewsPage.tsx
+++ b/src/pages/News/NewsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import ShareModal from '@/components/ShareModal';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import {
@@ -49,6 +49,7 @@ const NewsPage: React.FC = () => {
   const [categories, setCategories] = useState<string[]>([]);
   const [activeCategory, setActiveCategory] = useState<string>('All');
   const [currentPage, setCurrentPage] = useState<number>(1);
+  const articlesRef = useRef<HTMLDivElement>(null);
   const itemsPerPage = 9;
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -171,7 +172,9 @@ const NewsPage: React.FC = () => {
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    if (articlesRef.current) {
+      articlesRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
   };
 
   const handlePostClick = (slug: string) => {
@@ -278,7 +281,7 @@ const NewsPage: React.FC = () => {
             </div>
           </div>
 
-          <div className="container mx-auto px-4 py-8">
+          <div ref={articlesRef} className="container mx-auto px-4 py-8">
             {/* Enhanced Filters and Controls */}
             <div className="bg-white dark:bg-gray-800/50 dark:backdrop-blur-sm rounded-2xl shadow-xl p-6 mb-8 border border-gray-100 dark:border-gray-700">
               <div className="flex flex-col lg:flex-row gap-6">

--- a/src/pages/News/TagPage.tsx
+++ b/src/pages/News/TagPage.tsx
@@ -252,7 +252,10 @@ const TagPage: React.FC = () => {
 
           <div className="grid grid-cols-1 xl:grid-cols-4 gap-6 lg:gap-8">
             {/* Main Content */}
-            <div ref={articlesRef} className="xl:col-span-3">
+            <div
+              ref={articlesRef}
+              className="xl:col-span-3 scroll-mt-16 md:scroll-mt-20"
+            >
               {/* Controls */}
               {posts.length > 0 && (
                 <motion.div

--- a/src/pages/News/TagPage.tsx
+++ b/src/pages/News/TagPage.tsx
@@ -123,7 +123,10 @@ const TagPage: React.FC = () => {
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
     if (articlesRef.current) {
-      articlesRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      articlesRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
     }
   };
 

--- a/src/pages/News/TagPage.tsx
+++ b/src/pages/News/TagPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -33,6 +33,7 @@ const TagPage: React.FC = () => {
 
   // UI State
   const [currentPage, setCurrentPage] = useState(1);
+  const articlesRef = useRef<HTMLDivElement>(null);
   const itemsPerPage = 8;
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('All');
@@ -121,7 +122,9 @@ const TagPage: React.FC = () => {
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    if (articlesRef.current) {
+      articlesRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
   };
 
   const getUniqueCategories = () => {
@@ -246,7 +249,7 @@ const TagPage: React.FC = () => {
 
           <div className="grid grid-cols-1 xl:grid-cols-4 gap-6 lg:gap-8">
             {/* Main Content */}
-            <div className="xl:col-span-3">
+            <div ref={articlesRef} className="xl:col-span-3">
               {/* Controls */}
               {posts.length > 0 && (
                 <motion.div


### PR DESCRIPTION
## 📝 Description

When a user clicks any pagination button on the News, Author, or Tag pages,
the browser previously scrolled to the absolute top of the page (position 0),
landing behind the hero section. Users had to manually scroll past the hero
to find the new articles.

This fix attaches a `ref` to the articles/filter section in each page. On
page change, `handlePageChange` now calculates the scroll position using
`getBoundingClientRect().top + window.scrollY - 80` (accounting for the
fixed navbar height) and calls `window.scrollTo()` to land the user
precisely at the articles section.


## 🎥 Before vs After

### 🔴 Before Fix
https://github.com/user-attachments/assets/2d41f9d5-dae5-43a1-88fc-a6f0400ee9c2

### 🟢 After Fix

https://github.com/user-attachments/assets/a19abfe6-f52b-43b3-96e6-f1f1813a75a2


## 🔗 Related Issue

Fixes  #841 

## 🔄 Type of Change

- [x] 🐛 Bug Fix

## 🧪 Testing Performed

### 📱 Browser Compatibility
- [x] Chrome
- [x] Firefox

### 🖥️ Responsive Design
- [x] Desktop (1200px+)
- [x] Mobile (320px - 767px)

### ✅ Test Cases
1. Click pagination on /news/all → scrolls to search bar + articles ✅
2. Click pagination on /authors/:slug → scrolls to Articles section card ✅
3. Click pagination on /tags/:tag → scrolls to posts column ✅

## 📋 PR Checklist
- [x] My code follows the project's coding style guidelines
- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
