### PR TITLE
Update template to show how to add alt-text to images

### DIFF
--- a/src/constants/MarkdownFiles/posts/YYYY-MM-DD-GSoC_DMP_SSoC_Template.md
+++ b/src/constants/MarkdownFiles/posts/YYYY-MM-DD-GSoC_DMP_SSoC_Template.md
@@ -40,7 +40,7 @@ image: "assets/Images/GSOC.webp"
 
 3. **[Task or Feature]**  
    - Add screenshots or diagrams here if useful:
-   ![screenshot-description](https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=2070)
+   ![alt-text-description-for-visual-accessibility](https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=2070 "Image caption.")
 
 ---
 


### PR DESCRIPTION
I want students to get in the habit of adding alt-text to their images.

After doing some research, it seems that the syntax for markdown is:

`![alt-text](https://example.com/image.png "Image title")`

Ref: <https://md2word.com/en/markdown-image>

I tested it, and it seems to work.

Test, from a student blogpost:
<img width="1920" height="1200" alt="Screenshot From 2026-06-02 07-47-33" src="https://github.com/user-attachments/assets/df145394-3399-4f71-9eb2-cf9deb4a2974" />