### PR TITLE
Fix: Made Minor Changes in Navbar.

### DIFF
--- a/src/components/shared/DarkModeToggle.tsx
+++ b/src/components/shared/DarkModeToggle.tsx
@@ -29,7 +29,7 @@ const DarkModeToggle = () => {
   const thumbWidth = 28;
   const padding = 3;
 
-  const translateX = isDarkMode ? trackWidth - thumbWidth - padding : padding;
+  const translateX = isDarkMode ? padding : trackWidth - thumbWidth - padding;
 
   return (
     <button
@@ -124,20 +124,20 @@ const DarkModeToggle = () => {
         />
       </span>
 
-      <Sun
+      <Moon
         className="absolute left-2 top-1/2 -translate-y-1/2 transition-all duration-500"
         size={12}
         style={{
-          color: 'rgba(255, 255, 255, 0.9)',
-          opacity: isDarkMode ? 0.2 : 0.7,
+          color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : '#000000',
+          opacity: isDarkMode ? 0.2 : 0.8,
         }}
       />
-      <Moon
+      <Sun
         className="absolute right-2 top-1/2 -translate-y-1/2 transition-all duration-500"
         size={12}
         style={{
           color: 'rgba(255, 255, 255, 0.9)',
-          opacity: isDarkMode ? 0.7 : 0.2,
+          opacity: isDarkMode ? 0.8 : 0.2,
         }}
       />
     </button>

--- a/src/sections/NavDropdown.tsx
+++ b/src/sections/NavDropdown.tsx
@@ -28,8 +28,9 @@ const NavDropdown: React.FC<NavDropdownProps> = ({
       onMouseLeave={() => setActive(null)}
     >
       <button
-        className={`px-2 lg:px-3 py-2 text-gray-700 dark:text-gray-200 hover:text-blue-600 font-medium rounded-md
+        className={`px-2 lg:px-2 py-2 text-gray-700 dark:text-gray-200 hover:text-blue-600 font-medium rounded-md
                   transition-all duration-200 hover:bg-gray-50 dark:hover:bg-gray-800 flex items-center space-x-1
+                  text-sm lg:text-sm whitespace-nowrap
                   ${isActive ? 'text-blue-600 dark:text-blue-400' : ''}`}
         aria-expanded={isActive}
       >


### PR DESCRIPTION
Description
This PR addresses two UI/UX refinements: aligning the navigation dropdown text styles with the rest of the header links for a more cohesive navbar layout, and reworking the layout, icon positioning, and opacity logic for the dark mode toggle switch.

Before :
<img width="2558" height="1342" alt="Screenshot 2026-06-03 182146" src="https://github.com/user-attachments/assets/0d588567-b174-497d-99ab-96e3e2df34cf" />
After:
<img width="2539" height="1333" alt="Screenshot 2026-06-03 183446" src="https://github.com/user-attachments/assets/4ae13c7d-c87a-4ffe-986b-c44f6c0871f8" />

Key Changes
1. Unified Navigation Styling
File Modified: NavDropdown.tsx

Details: * Aligned the About dropdown menu button's font size and spacing to seamlessly match the standard header links.

Added utility classes: text-sm lg:text-sm and whitespace-nowrap to prevent awkward text wrapping.

Adjusted the padding to px-2 lg:px-2 to guarantee structural consistency across all navigation items.

2. Rearranged & Refined Dark Mode Toggle
File Modified: DarkModeToggle.tsx

Details:

Layout Swap: Reconfigured the slide positions so the Dark Mode (Moon) position sits on the left (first/default-left alignment) and the Light Mode (Sun) position sits on the right.

Icon Positions: Swapped the underlying background track icons to match the new layout (left-2 for the Moon icon, right-2 for the Sun icon).

Color & Opacity Logic: * Configured the background Moon icon to render with a solid black color (#000000) and a clear 0.8 opacity while in Light Mode.

Configured the background Sun icon to render with a crisp white color (#ffffff) and a matching 0.8 opacity while in Dark Mode.

Verification Checklist
[ ] Navigation dropdown layout perfectly matches adjacent header links.

[ ] No unwanted text-wrapping on the dropdown text across standard screen sizes.

[ ] Dark mode toggle transitions smoothly and icons align correctly with their new left/right track properties.

[ ] Opacity and color values render exactly as expected in both themes.