### PR TITLE
fix: align pagination bar layout

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -88,13 +88,13 @@ const Pagination: React.FC<PaginationProps> = ({
   if (totalPages <= 1) return null;
 
   return (
-    <div className="flex flex-wrap justify-center items-center gap-1 sm:gap-2 mt-12 mb-8">
+    <div className="flex items-center justify-center gap-1 sm:gap-2 mt-12 mb-8">
       <motion.button
         onClick={() => onPageChange(currentPage - 1)}
         disabled={currentPage === 1}
         whileHover={{ scale: 1.1 }}
         whileTap={{ scale: 0.9 }}
-        className={`p-2 sm:p-3 rounded-lg sm:rounded-xl flex items-center justify-center transition-all duration-300 ${
+        className={`w-8 h-8 sm:w-10 sm:h-10 rounded-lg sm:rounded-xl flex items-center justify-center transition-all duration-300 ${
           currentPage === 1
             ? 'bg-gray-100 text-gray-400 cursor-not-allowed dark:bg-gray-800 dark:text-gray-600'
             : 'bg-gradient-to-br from-blue-500 to-green-500 text-white shadow-lg hover:shadow-xl'
@@ -104,11 +104,11 @@ const Pagination: React.FC<PaginationProps> = ({
         <ChevronLeft size={20} className="w-4 h-4 sm:w-5 sm:h-5" />
       </motion.button>
 
-      <div className="flex flex-wrap justify-center bg-white dark:bg-gray-800 rounded-xl sm:rounded-2xl shadow-sm px-2 sm:px-4 py-1 sm:py-2 gap-1 sm:gap-2 items-center">
+      <div className="flex items-center justify-center bg-white dark:bg-gray-800 rounded-xl sm:rounded-2xl shadow-sm px-2 sm:px-4 py-1 sm:py-2 gap-1 sm:gap-2">
         {getPageNumbers().map((page, index) => (
           <React.Fragment key={index}>
             {page === '...' ? (
-              <span className="text-gray-400 px-1 sm:px-2 text-xs sm:text-base">
+              <span className="w-8 h-8 sm:w-10 sm:h-10 flex items-center justify-center text-gray-400 text-xs sm:text-base">
                 ...
               </span>
             ) : (
@@ -118,7 +118,7 @@ const Pagination: React.FC<PaginationProps> = ({
                 whileTap={{ scale: 0.9 }}
                 className={`w-8 h-8 sm:w-10 sm:h-10 rounded-lg sm:rounded-xl flex items-center justify-center text-xs sm:text-sm font-bold transition-all duration-300 ${
                   currentPage === page
-                    ? 'bg-gradient-to-br from-blue-600 to-green-600 text-white shadow-md transform -translate-y-1'
+                    ? 'bg-gradient-to-br from-blue-600 to-green-600 text-white shadow-md'
                     : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`}
               >
@@ -134,7 +134,7 @@ const Pagination: React.FC<PaginationProps> = ({
         disabled={currentPage === totalPages}
         whileHover={{ scale: 1.1 }}
         whileTap={{ scale: 0.9 }}
-        className={`p-2 sm:p-3 rounded-lg sm:rounded-xl flex items-center justify-center transition-all duration-300 ${
+        className={`w-8 h-8 sm:w-10 sm:h-10 rounded-lg sm:rounded-xl flex items-center justify-center transition-all duration-300 ${
           currentPage === totalPages
             ? 'bg-gray-100 text-gray-400 cursor-not-allowed dark:bg-gray-800 dark:text-gray-600'
             : 'bg-gradient-to-br from-blue-500 to-green-500 text-white shadow-lg hover:shadow-xl'


### PR DESCRIPTION
## 📝 Description

Fixes a layout misalignment in the `Pagination` component where the active page button (e.g. "31") was visually shifted upward out of the flex row, making it appear uncentered compared to adjacent page buttons and the prev/next controls.

Root cause: `transform -translate-y-1` on the active button's class string lifted it out of the row. Secondary issues: `flex-wrap` on both containers allowed layout drift, the prev/next buttons used padding-based sizing instead of fixed dimensions, and the ellipsis `...` span had no fixed width — all of which combined to produce uneven spacing.

## 🔗 Related Issue

Fixes #

## 🔄 Type of Change

- [ ] 📱 New Feature (new page, component, or functionality)
- [x] 🎨 UI/UX Update (visual changes, styling improvements)
- [ ] 📖 Content Update (text changes, documentation)
- [x] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [ ] ♿ Accessibility Enhancement
- [ ] 🔒 Security Update
- [ ] 📦 Dependency Update
- [ ] 🧹 Code Refactoring
- [ ] 🧪 Test Updates

## 📷 Visual Changes

<details>
<summary>Screenshots / GIFs</summary>

<!-- Before: active page button is shifted upward, breaking row alignment -->
<img width="492" height="103" alt="Screenshot 2026-06-09 at 3 28 33 PM" src="https://github.com/user-attachments/assets/b27bb9c9-3204-4f2a-8fe1-0a6bf7497081" />
<!-- After: all pagination items sit on the same baseline -->
<img width="450" height="108" alt="Screenshot 2026-06-09 at 3 49 59 PM" src="https://github.com/user-attachments/assets/36f2f60b-dbe8-461f-8377-188b99b3f766" />
<!-- Drag and drop your screenshots here -->

</details>

## 🧪 Testing Performed

### 📱 Browser Compatibility

- [ ] Chrome (Version: )
- [ ] Firefox (Version: )
- [ ] Safari (Version: )
- [ ] Edge (Version: )
- [ ] Mobile Chrome (Device: )
- [ ] Mobile Safari (Device: )

### 🖥️ Responsive Design

- [x] Desktop (1200px+)
- [x] Tablet (768px - 1199px)
- [x] Mobile (320px - 767px)

### ✅ Test Cases

1. Active page button sits on the same baseline as all other page number buttons — no upward shift.
2. Prev/next arrow buttons are the same fixed height (`w-8 h-8 sm:w-10 sm:h-10`) as page buttons, maintaining a uniform row.
3. Ellipsis `...` span occupies an equal fixed slot so surrounding buttons do not compress or expand.

## ♿ Accessibility

- [x] Proper heading hierarchy maintained
- [x] ARIA labels added where needed
- [x] Color contrast requirements met
- [x] Keyboard navigation works correctly
- [ ] Screen reader testing performed

## 📋 PR Checklist

- [x] My code follows the project's coding style guidelines
- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or console errors
- [ ] I have added tests that prove my fix/feature works
- [ ] All existing tests pass successfully
- [x] I have checked for and resolved any merge conflicts
- [ ] I have optimized images/assets (if applicable)
- [x] I have validated all links are working correctly

## 💭 Additional Notes

Changes are isolated to `src/components/Pagination.tsx`. Summary of what changed:

- Removed `transform -translate-y-1` from the active page button (root cause of the vertical shift).
- Replaced `flex-wrap` with `flex items-center justify-center` on both the outer wrapper and the inner page-number pill.
- Changed prev/next buttons from `p-2 sm:p-3` to explicit `w-8 h-8 sm:w-10 sm:h-10` to match page button dimensions.
- Gave the `...` ellipsis span `w-8 h-8 sm:w-10 sm:h-10 flex items-center justify-center` so it takes up equal space.
