### PR TITLE
docs: added GSoC '26 Week 6 progress by dev

### DIFF
--- a/src/constants/MarkdownFiles/posts/2026-07-05-gsoc-26-dev-week06.md
+++ b/src/constants/MarkdownFiles/posts/2026-07-05-gsoc-26-dev-week06.md
@@ -34,17 +34,17 @@ image: "assets/Images/GSOC.webp"
 *Hey everyone! This week was all about addressing feedback on the main pull request and getting the codebase completely clean and stable.*
 
 1. **Resolving PR Review Feedback**  
-   I worked closely with [Ibiam](https://github.com/chimosky) to clean up the code modifications. 
+   I worked closely with Ibiam to clean up the code modifications. 
    - I updated the hardcoded screenshot resolution fallback in [screenshot.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3488671462) to only act as a safeguard. The active monitor geometry is now fetched dynamically using Gdk.Display.
    - I removed the redundant empty `start` hook inside [session.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3488679934) since it had no active function.
 
 2. **PEP8 Compliance and Spacing Cleanups**  
-   [Ibiam](https://github.com/chimosky) pointed out that my coding workflow was stripping blank lines before class and function definitions. I went through the files to restore the correct spacing.
+   Ibiam pointed out that my coding workflow was stripping blank lines before class and function definitions. I went through the files to restore the correct spacing.
    - I added two blank lines before all top-level class definitions to match the style guide.
    - You can see some of these comments and discussions on files like [homebox.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3521065900) and [homewindow.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3521105663). I also updated files like `grid.py` and `schoolserver.py` to keep the codebase consistent.
 
 3. **Fixing Runtime Crashes and File Descriptor Leaks**  
-   [Krish](https://github.com/MostlyKIGuess) ran the ported shell locally and shared some critical runtime notes:
+   Krish ran the ported shell locally and shared some critical runtime notes:
    - **Palettes Crash:** The volume and journal palettes crashed because `PaletteMenuItem` has no `set_icon_widget` method in GTK4. I replaced it with `set_image` to align with the toolkit. The discussion is located at [palettes.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3524721118).
    - **Object Chooser Parent Window:** The object chooser failed to open in the journal because it was trying to set a `Gtk.Box` parent as transient window. I modified the initializer to pass `None` which safely falls back to the main shell window. You can check the thread at [journalactivity.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3524721124).
    - **Wayland Socket Leak:** The compositor file descriptor was leaking during activity launches. I added a cleanup block with `os.close(fd)` right after the subprocess spawn to prevent leaks. The review details are at [activityfactory.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3524721125).

--- a/src/constants/MarkdownFiles/posts/2026-07-05-gsoc-26-dev-week06.md
+++ b/src/constants/MarkdownFiles/posts/2026-07-05-gsoc-26-dev-week06.md
@@ -34,7 +34,7 @@ image: "assets/Images/GSOC.webp"
 *Hey everyone! This week was all about addressing feedback on the main pull request and getting the codebase completely clean and stable.*
 
 1. **Resolving PR Review Feedback**  
-   I worked closely with Ibiam to clean up the code modifications. 
+   I worked closely with [Ibiam](https://github.com/chimosky) to clean up the code modifications. 
    - I updated the hardcoded screenshot resolution fallback in [screenshot.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3488671462) to only act as a safeguard. The active monitor geometry is now fetched dynamically using Gdk.Display.
    - I removed the redundant empty `start` hook inside [session.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3488679934) since it had no active function.
 
@@ -44,7 +44,7 @@ image: "assets/Images/GSOC.webp"
    - You can see some of these comments and discussions on files like [homebox.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3521065900) and [homewindow.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3521105663). I also updated files like `grid.py` and `schoolserver.py` to keep the codebase consistent.
 
 3. **Fixing Runtime Crashes and File Descriptor Leaks**  
-   Krish ran the ported shell locally and shared some critical runtime notes:
+   [Krish](https://github.com/MostlyKIGuess) ran the ported shell locally and shared some critical runtime notes:
    - **Palettes Crash:** The volume and journal palettes crashed because `PaletteMenuItem` has no `set_icon_widget` method in GTK4. I replaced it with `set_image` to align with the toolkit. The discussion is located at [palettes.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3524721118).
    - **Object Chooser Parent Window:** The object chooser failed to open in the journal because it was trying to set a `Gtk.Box` parent as transient window. I modified the initializer to pass `None` which safely falls back to the main shell window. You can check the thread at [journalactivity.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3524721124).
    - **Wayland Socket Leak:** The compositor file descriptor was leaking during activity launches. I added a cleanup block with `os.close(fd)` right after the subprocess spawn to prevent leaks. The review details are at [activityfactory.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3524721125).

--- a/src/constants/MarkdownFiles/posts/2026-07-05-gsoc-26-dev-week06.md
+++ b/src/constants/MarkdownFiles/posts/2026-07-05-gsoc-26-dev-week06.md
@@ -1,0 +1,94 @@
+---
+title: "GSoC '26 Week 06 Update by Dev"
+excerpt: "Addressing PR review comments on PEP8 spacing and updating screenshot monitor checks along with fixing critical runtime crashes in the palettes and object chooser."
+category: "DEVELOPER NEWS"
+date: "2026-07-05"
+slug: "2026-07-05-gsoc-26-dev-week06"
+author: "@/constants/MarkdownFiles/authors/dev.md"
+tags: "gsoc26,sugarlabs,week06,dev,gtk4-port,Sugar shell"
+image: "assets/Images/GSOC.webp"
+---
+
+<!-- markdownlint-disable -->
+
+# Week 06 Progress Report by Dev
+
+**Project:** [GTK4 Transition Part 2: Sugar Shell](https://github.com/sugarlabs/GSoC/blob/master/Ideas-2026.md#gtk4-transition-part-2-sugar-shell)  
+**Mentors:** [Krish Pandya](https://github.com/MostlyKIGuess), [Ibiam Chihurumnaya](https://github.com/chimosky)  
+**Assisting Mentors:** [Walter Bender](https://github.com/walterbender), [Juan Pablo Ugarte](https://github.com/xjuan)  
+**Organization:** [Sugar Labs](https://sugarlabs.org)  
+**Reporting Period:** 2026-06-28 - 2026-07-04  
+
+---
+
+## Goals for This Week
+
+- **Goal 1:** Walk through the initial PR review comments from the maintainers and resolve them.
+- **Goal 2:** Address PEP8 compliance issues across the modified python files.
+- **Goal 3:** Stabilize the boot flow by fixing runtime crashes found during testing.
+
+---
+
+## This Week's Achievements
+
+*Hey everyone! This week was all about addressing feedback on the main pull request and getting the codebase completely clean and stable.*
+
+1. **Resolving PR Review Feedback**  
+   I worked closely with [Ibiam](https://github.com/chimosky) to clean up the code modifications. 
+   - I updated the hardcoded screenshot resolution fallback in [screenshot.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3488671462) to only act as a safeguard. The active monitor geometry is now fetched dynamically using Gdk.Display.
+   - I removed the redundant empty `start` hook inside [session.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3488679934) since it had no active function.
+
+2. **PEP8 Compliance and Spacing Cleanups**  
+   [Ibiam](https://github.com/chimosky) pointed out that my coding workflow was stripping blank lines before class and function definitions. I went through the files to restore the correct spacing.
+   - I added two blank lines before all top-level class definitions to match the style guide.
+   - You can see some of these comments and discussions on files like [homebox.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3521065900) and [homewindow.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3521105663). I also updated files like `grid.py` and `schoolserver.py` to keep the codebase consistent.
+
+3. **Fixing Runtime Crashes and File Descriptor Leaks**  
+   [Krish](https://github.com/MostlyKIGuess) ran the ported shell locally and shared some critical runtime notes:
+   - **Palettes Crash:** The volume and journal palettes crashed because `PaletteMenuItem` has no `set_icon_widget` method in GTK4. I replaced it with `set_image` to align with the toolkit. The discussion is located at [palettes.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3524721118).
+   - **Object Chooser Parent Window:** The object chooser failed to open in the journal because it was trying to set a `Gtk.Box` parent as transient window. I modified the initializer to pass `None` which safely falls back to the main shell window. You can check the thread at [journalactivity.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3524721124).
+   - **Wayland Socket Leak:** The compositor file descriptor was leaking during activity launches. I added a cleanup block with `os.close(fd)` right after the subprocess spawn to prevent leaks. The review details are at [activityfactory.py](https://github.com/sugarlabs/sugar/pull/1106#discussion_r3524721125).
+
+4. **Keyboard Settings Migration & CSS Overrides**  
+   - I replaced `libxklavier` with native XKB XML parsing (`evdev.xml`) to dynamically load layout options/variants instead of crashing on Wayland.
+   - I cleaned up visual warnings in `sugar.css` by removing the invalid `!important` lines.
+
+---
+
+## Challenges & How I Overcame Them
+
+- **Challenge:** Tracking down spacing regressions and maintaining PEP8 styling without automated tools messing up formatting.  
+  **Solution:** I configured my text editor to respect python spacing rules instead of stripping lines. I did a manual audit of all modified files to ensure they conform to the Sugarlabs python style guidelines. It was a good learning experience and helped me understand code review cycles much better.
+
+---
+
+## Key Learnings
+
+- Code styling and PEP8 spacing are just as important as functional changes when submitting patches to upstream repositories.
+- Custom widgets like `PaletteMenuItem` in GTK4 require strict method parity with the toolkit.
+- Managing low-level file descriptors requires explicit cleanup blocks to prevent resource leaks over long sessions.
+
+---
+
+## Next Week's Roadmap
+
+- Run end-to-end testing, debug runtime edge cases, and continue addressing reviews or feedback that the maintainers provide.
+
+---
+
+## Resources & References
+
+- Sugar Shell Repository - [sugar](https://github.com/sugarlabs/sugar)
+- GTK4 Toolkit Library - [sugar-toolkit-gtk4](https://github.com/sugarlabs/sugar-toolkit-gtk4)
+- Documentation - [Read the Docs](https://sugar-toolkit-gtk4.readthedocs.io/en/latest/)
+- GTK4 Migration Guide - [GNOME Docs](https://docs.gtk.org/gtk4/migrating-3to4.html)
+- PyPI Package - [sugar-toolkit-gtk4](https://pypi.org/project/sugar-toolkit-gtk4/)
+- Sugar Ext Repository - [sugar-ext](https://github.com/sugarlabs/sugar-ext)
+- Casilda Compositor - [Casilda](https://gitlab.gnome.org/jpu/casilda/-/tree/main?ref_type=heads)
+- Sugar Artwork Repository - [sugar-artwork](https://github.com/sugarlabs/sugar-artwork)
+
+---
+
+## Acknowledgments
+
+Thanks to my mentors for the detailed review feedback! Working through these commits has been a great learning curve for understanding production-ready code guidelines.


### PR DESCRIPTION
Adds the Week 6 GSoC progress blog post.

This blog details the resolution of PR review feedback from the maintainers, including PEP8 formatting fixes, screenshot resolution fallback updates, and runtime fixes for the palettes and file descriptor leaks under Wayland. It also covers the keyboard settings migration to native XKB XML parsing .