### PR TITLE
docs: add GSoC '26 week 07 progress report by Dev

### DIFF
--- a/src/constants/MarkdownFiles/posts/2026-07-12-gsoc-26-dev-week07.md
+++ b/src/constants/MarkdownFiles/posts/2026-07-12-gsoc-26-dev-week07.md
@@ -1,0 +1,96 @@
+---
+title: "GSoC '26 Week 07 Update by Dev"
+excerpt: "Identifying and fixing C extension memory crashes in sugar-ext locally, resolving popover autohide in sugar-toolkit-gtk4, and integrating external GTK4 artwork theme in Sugar shell."
+category: "DEVELOPER NEWS"
+date: "2026-07-12"
+slug: "2026-07-12-gsoc-26-dev-week07"
+author: "@/constants/MarkdownFiles/authors/dev.md"
+tags: "gsoc26,sugarlabs,week07,dev,gtk4-port,Sugar shell"
+image: "assets/Images/GSOC.webp"
+---
+
+<!-- markdownlint-disable -->
+
+# Week 07 Progress Report by Dev
+
+**Project:** [GTK4 Transition Part 2: Sugar Shell](https://github.com/sugarlabs/GSoC/blob/master/Ideas-2026.md#gtk4-transition-part-2-sugar-shell)  
+**Mentors:** [Krish Pandya](https://github.com/MostlyKIGuess), [Ibiam Chihurumnaya](https://github.com/chimosky)  
+**Assisting Mentors:** [Walter Bender](https://github.com/walterbender), [Juan Pablo Ugarte](https://github.com/xjuan)  
+**Organization:** [Sugar Labs](https://sugarlabs.org)  
+**Reporting Period:** 2026-07-05 - 2026-07-11  
+
+---
+
+## Goals for This Week
+
+- **Goal 1:** Identify and fix legacy C extension memory crashes and GDK4 event regressions in `sugar-ext` through local build testing.
+- **Goal 2:** Address Wayland popover interaction and autohide bugs in `sugar-toolkit-gtk4`.
+- **Goal 3:** Integrate the external GTK4 artwork stylesheet and enforce strict `GDK_BACKEND=wayland` session flags in the Sugar shell.
+
+---
+
+## This Week's Achievements
+
+This week focused on local debugging and memory safety fixes for the low-level C helper library (`sugar-ext`), resolving GTK4 popover event issues in the toolkit, and cleanly separating theme resources.
+
+1. **Local C Extension Bug Fixes (`sugar-ext`)**  
+   While running local integration builds, I investigated stability issues in `sugar-ext` used for input controllers and clipboard operations:
+   - **Clipboard Binary Safety:** Updated `sugar_clipboard_set_with_data` in `sugar-clipboard.c` to accept a `GBytes` container rather than raw pointer lengths. This prevents payload truncation and memory corruption during 64-bit clipboard operations.
+   - **GDK4 Surface Event Coordinates:** Ported touch and motion position getters in `sugar-event-controller.c` and `sugar-long-press-controller.c` to GDK4 floating-point (`gdouble`) surface coordinates. Fixed destruction ordering in `sugar_event_controller_detach` to unhook signal handlers before freeing controller instances, resolving use-after-free crashes during touch events.
+   - **Slice Allocator Deprecation:** Replaced legacy GLib slice allocators (`g_slice_new`, `g_slice_free`) with standard `g_new0` and `g_free`. Updated Meson configuration (`src/meson.build`) so `pkg.generate()` passes the target library object directly.
+   - I thoroughly verified these C library patches in local build tests before preparing the final repository push.
+
+2. **Toolkit Interactions & Module Relocation (`sugar-toolkit-gtk4`)**  
+   In [sugar-toolkit-gtk4 PR #33](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33), I addressed popover dismissals and missing utility modules:
+   - **Popover Dismissal & Parent Binding:** Fixed assertions during palette popover parent binding and added recursive parent traversal on item activation to close active popovers smoothly.
+   - **Activity Factory Relocation:** Moved `activityfactory.py` back to `sugar-toolkit-gtk4` from the shell repository, keeping activity lifecycle utilities inside the toolkit.
+   - **Commits:** [Fix palette interaction and autohide](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33/commits/588ab0a7), [Replace GTK3 signals](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33/commits/02479d27), [Fix palette parent assertion](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33/commits/f712f135), [Add activityfactory to toolkit](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33/commits/444931f6).
+
+3. **Sugar Shell Theme Separation & Wayland Session (`sugar`)**  
+   In [sugar PR #1106](https://github.com/sugarlabs/sugar/pull/1106), I refined session flags and styling management:
+   - **Theme Delegation:** Removed bundled `sugar.css` overrides from the shell source tree to rely on the dedicated GTK4 theme in `sugar-artwork`.
+   - **Wayland Backend Enforcement:** Explicitly set `GDK_BACKEND=wayland` during shell initialization to guarantee native surface allocation under the Casilda compositor.
+   - **Commits:** [Replace removed GTK3 widget signals](https://github.com/sugarlabs/sugar/pull/1106/commits/ffce4130), [Rely on sugar-artwork GTK4 theme](https://github.com/sugarlabs/sugar/pull/1106/commits/b7df9ccd), [Enforce Wayland backend](https://github.com/sugarlabs/sugar/pull/1106/commits/3179f5f0), [Fix runtime crashes and fd leaks](https://github.com/sugarlabs/sugar/pull/1106/commits/044ad7d8).
+
+---
+
+## Challenges & How I Overcame Them
+
+* **Use-After-Free in C Event Controllers**  
+  During touch event testing in `sugar-long-press-controller.c`, tearing down widgets while touch gestures were active caused intermittent segfaults. Tracing the teardown revealed that controller object references were freed before disconnecting signal handlers. Reordering destruction logic resolved the crash cleanly.
+
+* **Binary Truncation on 64-bit Systems**  
+  Passing raw integer lengths for clipboard buffers was truncating data structures on 64-bit architectures. Switching `sugar_clipboard_set_with_data` to wrap memory buffers in `GBytes` fixed data integrity across clipboard transfers.
+
+---
+
+## Key Learnings
+
+- GDK4 surface coordinates use floating-point precision (`gdouble`), making event positioning smoother than legacy X11 integer coordinates.
+- C libraries bound through GObject Introspection must use standard `g_new0`/`g_free` allocators rather than legacy slice allocators for robust memory management.
+
+---
+
+## Next Week's Roadmap
+
+- Finalize testing for the remaining `sugar-ext` controller fixes and submit the official GTK4 migration PR for `sugar-ext`.
+- Perform a comprehensive codebase audit to eliminate lingering GTK3 container removal calls (`container.remove(child)`) across all shell components.
+- Fix Wayland popover grab inhibition in `palettewindow.py` by transitioning to non-blocking pointer tracking.
+
+---
+
+## Resources & References
+
+- GTK4 Toolkit Library - [sugar-toolkit-gtk4](https://github.com/sugarlabs/sugar-toolkit-gtk4)
+- Documentation - [Read the Docs](https://sugar-toolkit-gtk4.readthedocs.io/en/latest/)
+- GTK4 Migration Guide - [GNOME Docs](https://docs.gtk.org/gtk4/migrating-3to4.html)
+- PyPI Package - [sugar-toolkit-gtk4](https://pypi.org/project/sugar-toolkit-gtk4/)
+- Sugar Ext Repository - [sugar-ext](https://github.com/sugarlabs/sugar-ext)
+- Casilda Compositor - [Casilda](https://gitlab.gnome.org/jpu/casilda/-/tree/main?ref_type=heads)
+- Sugar Artwork Repository - [sugar-artwork](https://github.com/sugarlabs/sugar-artwork)
+
+---
+
+## Acknowledgments
+
+Special thanks to my mentors Krish Pandya, Ibiam Chihurumnaya, Walter Bender, and Juan Pablo Ugarte for their guidance and support!


### PR DESCRIPTION
This PR adds the GSoC '26 Week 07 progress report blog post.

- Covers local `sugar-ext` C library memory safety fixes (`GBytes` clipboard, GDK4 surface coordinates).
- Covers `sugar-toolkit-gtk4` popover interaction fixes and `activityfactory` relocation.
- Covers delegating shell theme loading to `sugar-artwork` GTK4 theme.