### PR TITLE
docs: add GSoC '26 week 08 progress report by Dev

### DIFF
--- a/src/constants/MarkdownFiles/posts/2026-07-19-gsoc-26-dev-week08.md
+++ b/src/constants/MarkdownFiles/posts/2026-07-19-gsoc-26-dev-week08.md
@@ -1,0 +1,97 @@
+---
+title: "GSoC '26 Week 08 Update by Dev"
+excerpt: "Submitting sugar-ext GTK4 migration PR, conducting deep API audit across Sugar shell and toolkit, and replacing legacy container removal calls with unparent."
+category: "DEVELOPER NEWS"
+date: "2026-07-19"
+slug: "2026-07-19-gsoc-26-dev-week08"
+author: "@/constants/MarkdownFiles/authors/dev.md"
+tags: "gsoc26,sugarlabs,week08,dev,gtk4-port,Sugar shell"
+image: "assets/Images/GSOC.webp"
+---
+
+<!-- markdownlint-disable -->
+
+# Week 08 Progress Report by Dev
+
+**Project:** [GTK4 Transition Part 2: Sugar Shell](https://github.com/sugarlabs/GSoC/blob/master/Ideas-2026.md#gtk4-transition-part-2-sugar-shell)  
+**Mentors:** [Krish Pandya](https://github.com/MostlyKIGuess), [Ibiam Chihurumnaya](https://github.com/chimosky)  
+**Assisting Mentors:** [Walter Bender](https://github.com/walterbender), [Juan Pablo Ugarte](https://github.com/xjuan)  
+**Organization:** [Sugar Labs](https://sugarlabs.org)  
+**Reporting Period:** 2026-07-12 - 2026-07-18  
+
+---
+
+## Goals for This Week
+
+- **Goal 1:** Finalize C extension fixes, resolve mouse event sequence checks, and submit the official `sugar-ext` GTK4 migration PR.
+- **Goal 2:** Audit the entire `sugar` shell codebase to remove invalid GTK3 container methods (`container.remove(child)`).
+- **Goal 3:** Resolve Wayland popover grab issues and `Gsk.Transform` binding crashes in `sugar-toolkit-gtk4`.
+
+---
+
+## This Week's Achievements
+
+This week focused on submitting the finalized `sugar-ext` pull request and performing a comprehensive GTK4 API audit across both the shell and toolkit repositories.
+
+1. **Finalizing C Extensions & Submitting PR (`sugar-ext`)**  
+   After completing local integration testing on Debian, I resolved the remaining edge-case bugs in `sugar-ext`:
+   - **Mouse Swipe Event Fix:** Fixed mouse event rejection in `sugar-swipe-controller.c` where a null sequence check was accidentally discarding pointer-driven swipes (which lack a `GdkEventSequence`).
+   - **Compiler & Memory Cleanups:** Fixed discarded `const` qualifier warnings in `sugar-fatattr.c` under `-Wcast-qual` and chained parent `GObjectClass.finalize` in `sugar-grid.c` to prevent instance memory leaks.
+   - **PR Submission:** Pushed the squashed commits and submitted the official [sugar-ext GTK4 Migration PR #6](https://github.com/sugarlabs/sugar-ext/pull/6).
+
+2. **Systematic GTK4 Container Migration (`sugar`)**  
+   In [sugar PR #1106](https://github.com/sugarlabs/sugar/pull/1106), I audited and updated widget lifecycle operations across Frame and Journal modules:
+   - **`unparent()` Migration:** Replaced invalid `container.remove(child)` calls with GTK4 native `child.unparent()` across `activitiestray.py`, `frame.py`, `notification.py`, `listview.py`, and `journaltoolbox.py`.
+   - **Palette Chain Helper:** Deduplicated palette dismissal logic across `VolumeMenu`, `ClipboardMenu`, `FriendsMenu`, and `StartWithMenu` in `palettes.py` into a unified `_popdown_palette_chain()` helper.
+   - **Device Icons & Battery D-Bus:** Migrated `PaletteMenuItem` icons and fixed battery device property checks in `deviceicon` extensions.
+   - **Commits:** [Migrate PaletteMenuItem icons and battery client](https://github.com/sugarlabs/sugar/pull/1106/commits/0aa7dee7), [Fix battery device kind check](https://github.com/sugarlabs/sugar/pull/1106/commits/73a2bbdb), [Fix GTK4 widget removal and clean up migration artifacts](https://github.com/sugarlabs/sugar/pull/1106/commits/aca93ff1).
+
+3. **Toolkit Popover Grabs & Animator Fixes (`sugar-toolkit-gtk4`)**  
+   In [sugar-toolkit-gtk4 PR #33](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33), I resolved rendering crashes and popover focus grabs:
+   - **Wayland Popover Grabs:** Fixed popover grab inhibition under Wayland by setting `autohide(False)` on `_PaletteWindowWidget` and implementing non-blocking pointer tracking to handle dismissal cleanly.
+   - **Cairo Pixbuf Painting:** Replaced removed `Gdk.cairo_set_source_pixbuf` calls with modern snapshot-based drawing routines in `icon.py`.
+   - **Animator Binding Fix:** Replaced non-existent `Gsk.Transform` Python bindings in `animator.py` with standard widget margin and opacity property animations.
+   - **Commits:** [Fix Gdk.cairo_set_source_pixbuf removal](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33/commits/967a5b03), [Fix grabbing popups on Wayland](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33/commits/3c91b0da), [Fix GTK4 API mismatches in palette, animator, and palettewindow](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33/commits/5df6212e).
+
+---
+
+## Challenges & How I Overcame Them
+
+* **`container.remove()` Runtime Failures**  
+  In GTK4, `Gtk.Container` was removed, so calling `container.remove(child)` raises an `AttributeError`. Replacing these calls with `child.unparent()` ensures widgets are correctly detached from the layout hierarchy without throwing runtime errors.
+
+* **Wayland Popover Grab Inhibition**  
+  `Gtk.Popover` autohide grabs focus aggressively on Wayland, preventing pointer events from reaching underlying shell elements. Disabling automatic autohide and handling dismissal via pointer tracking allowed popovers to co-exist with shell desktop interactions.
+
+---
+
+## Key Learnings
+
+- `GtkWidget.unparent()` is the universal GTK4 method for detaching widgets from any parent container.
+- GTK4 Python bindings do not expose direct `Gsk.Transform` mutation methods on `GtkWidget`, so animating margins and opacity properties is the standard Python approach.
+
+---
+
+## Next Week's Roadmap
+
+- Run extensive end-to-end boot tests across all desktop views (Home, Journal, Control Panel, Frame) under Casilda.
+- Prepare PR summaries and technical documentation for maintainer final reviews.
+- Coordinate with mentors for initial integration testing on Debian Live environments.
+
+---
+
+## Resources & References
+
+- GTK4 Toolkit Library - [sugar-toolkit-gtk4](https://github.com/sugarlabs/sugar-toolkit-gtk4)
+- Documentation - [Read the Docs](https://sugar-toolkit-gtk4.readthedocs.io/en/latest/)
+- GTK4 Migration Guide - [GNOME Docs](https://docs.gtk.org/gtk4/migrating-3to4.html)
+- PyPI Package - [sugar-toolkit-gtk4](https://pypi.org/project/sugar-toolkit-gtk4/)
+- Sugar Ext Repository - [sugar-ext](https://github.com/sugarlabs/sugar-ext)
+- Casilda Compositor - [Casilda](https://gitlab.gnome.org/jpu/casilda/-/tree/main?ref_type=heads)
+- Sugar Artwork Repository - [sugar-artwork](https://github.com/sugarlabs/sugar-artwork)
+
+---
+
+## Acknowledgments
+
+Special thanks to my mentors Krish Pandya, Ibiam Chihurumnaya, Walter Bender, and Juan Pablo Ugarte for their guidance and support!


### PR DESCRIPTION
This PR adds the GSoC '26 Week 08 progress report blog post.

- Covers submitting the official `sugar-ext` GTK4 migration PR #6.
- Covers systematic GTK4 container migration in the Sugar shell (replacing `container.remove()` with `child.unparent()`).
- Covers resolving Wayland popover grab inhibition and animator fixes in `sugar-toolkit-gtk4`.