### PR TITLE
fix: remove out-of-stock USB product

### DIFF
--- a/src/constants/ProductsData.ts
+++ b/src/constants/ProductsData.ts
@@ -18,13 +18,13 @@ export const products: ProductType[] = [
     },
     link: 'https://www.bonfire.com/store/sugar-labs-merch/', // Purchase link
   },
-  {
-    name: 'SugarLabs USB',
-    description:
-      'Easily install Fedora Sugar On A Stick (SOAS) to your device directly from this USB flash drive. The Fedora SOAS on this USB drive is for Intel and AMD x86_64 systems.',
-    colors: {
-      white: 'assets/Products/sugarlabsUsb.webp',
-    },
-    link: 'https://www.usbmemorydirect.com/store/novelty/sugarlabs/', // Purchase link
-  },
+  // {
+  //   name: 'SugarLabs USB',
+  //   description:
+  //     'Easily install Fedora Sugar On A Stick (SOAS) to your device directly from this USB flash drive. The Fedora SOAS on this USB drive is for Intel and AMD x86_64 systems.',
+  //   colors: {
+  //     white: 'assets/Products/sugarlabsUsb.webp',
+  //   },
+  //   link: 'https://www.usbmemorydirect.com/store/novelty/sugarlabs/', // Purchase link
+  // },
 ];


### PR DESCRIPTION
## 📝 Description

Removed the permanently out-of-stock **SugarLabs USB** from the Products page by deleting its product entry.

I also reviewed other USB-related references in the repository and left historical blog posts and annual report content unchanged, as they document past announcements rather than active products.

---

## 🔗 Related Issue

Fixes #969

---

## 🔄 Type of Change

- [x] 📖 Content Update
- [x] 🐛 Bug Fix

---

## Visual changes
<img width="1280" height="800" alt="Screenshot 2026-07-26 at 6 55 48 PM" src="https://github.com/user-attachments/assets/fc26b678-2741-4105-af8d-3e25aa99bd8c" />
<img width="1280" height="800" alt="Screenshot 2026-07-26 at 6 56 01 PM" src="https://github.com/user-attachments/assets/35a4a2f6-b483-426e-a450-b48d9edf4bf5" />




## 🧪 Testing Performed

### 📱 Browser Compatibility

- [x] Chrome (Version: Latest)

### 🖥️ Responsive Design

- [x] Desktop (1200px+)

### ✅ Test Cases

1. Verified that the Products page loads successfully.
2. Confirmed that the SugarLabs USB product is no longer displayed.
3. Confirmed that the remaining product is displayed correctly.

---

## ♿ Accessibility

No accessibility-related changes.

---

## 📋 PR Checklist

- [x] My code follows the project's coding style guidelines
- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts

---

## 💭 Additional Notes

Historical blog posts and annual report references to the USB product were intentionally left unchanged, as they are archival content and not part of the active Products page.

### 📚 Reviewer Resources

- [Contributing Guide](https://github.com/sugarlabs/www-v2/blob/main/docs/CONTRIBUTING.md)
- [Style Guide](https://github.com/sugarlabs/www-v2/blob/main/docs/dev_guide.md)
- [Community Chat](https://matrix.to/#/#sugarlabs-web:matrix.org)

Thank you for contributing to the Sugar Labs website! 🎉
