### PR TITLE
docs: add GSoC '26 week 10 blog by Dev

### DIFF
--- a/src/constants/MarkdownFiles/posts/2026-08-02-gsoc-26-dev-week10.md
+++ b/src/constants/MarkdownFiles/posts/2026-08-02-gsoc-26-dev-week10.md
@@ -1,0 +1,91 @@
+---
+title: "GSoC '26 Week 10 Update by Dev"
+excerpt: "Running end-to-end tests on the full GTK4 shell, recording a live walkthrough video under Casilda, cleaning up review feedback on widget methods in sugar, and fixing palette popover parenting in sugar-toolkit-gtk4."
+category: "DEVELOPER NEWS"
+date: "2026-08-02"
+slug: "2026-08-02-gsoc-26-dev-week10"
+author: "@/constants/MarkdownFiles/authors/dev.md"
+tags: "gsoc26,sugarlabs,week10,dev,gtk4-port,Sugar shell"
+image: "assets/Images/GSOC.webp"
+---
+
+<!-- markdownlint-disable -->
+
+# Week 10 Progress Report by Dev
+
+**Project:** [GTK4 Transition Part 2: Sugar Shell](https://github.com/sugarlabs/GSoC/blob/master/Ideas-2026.md#gtk4-transition-part-2-sugar-shell)  
+**Mentors:** [Krish Pandya](https://github.com/MostlyKIGuess), [Ibiam Chihurumnaya](https://github.com/chimosky)  
+**Assisting Mentors:** [Walter Bender](https://github.com/walterbender), [Juan Pablo Ugarte](https://github.com/xjuan)  
+**Organization:** [Sugar Labs](https://sugarlabs.org)  
+**Reporting Period:** 2026-07-26 - 2026-08-01  
+
+---
+
+## Goals for This Week
+
+- **Goal 1:** Run a full end-to-end test of the GTK4 shell across the Home Screen, Journal, Frame and Control Panel and record a live walkthrough video.
+- **Goal 2:** Address PR review feedback from mentors on `sugar` regarding widget styling methods and compositor launcher cleanup.
+- **Goal 3:** Resolve palette popover attachment bugs and coordinate unpacking issues in `sugar-toolkit-gtk4`.
+
+---
+
+## This Week's Achievements
+
+1. **Live Video Walkthrough of the GTK4 Shell**  
+   I recorded a live walkthrough video showing the intro flow, Home Screen, Frame panels, and Journal all rendering on GTK4 Wayland under Casilda. You can watch it [here](https://drive.google.com/file/d/1faI1mk-qoiGLzVkZJ2fYIgfdhxPiaDqf/view?usp=sharing).
+
+2. **Resolving PR Review Feedback in `sugar`**  
+   After reviewing [PR #1106](https://github.com/sugarlabs/sugar/pull/1106) with [Ibiam](https://github.com/chimosky), I refactored the widget styling approach across journal views and control panel modules. Instead of injecting inline CSS strings via `load_from_string()`, the code now uses native `set_css_classes()` calls to align with GTK4 styling standards. I also cleaned up `activitiestray.py` and shell window handlers to drop legacy GTK3 methods, removed the old subprocess Casilda launcher from `main.py` since socket initialization is now handled natively by the shell compositor server, and updated container measurement in `viewcontainer.py` to use proper GTK4 sizing paths.  
+   Commit: [Fix GTK4 widget methods, review feedback and Wayland compositor cleanup](https://github.com/sugarlabs/sugar/pull/1106/commits/e8a61c99)
+
+3. **Fixing Palette Popover Attachment in `sugar-toolkit-gtk4`**  
+   While running tests on the toolkit side, I noticed palette menus failing to attach to their parent widgets in certain UI flows. Tracing `_PaletteMenuWidget.popup()` in `palettewindow.py` revealed a surface guard that was returning early before `set_parent()` attached the popover to its invoker. Removing that guard resolved popover attachment across the shell. In addition, I updated `translate_coordinates()` in `tray.py` to handle the tuple return structure changes in GTK4 PyGObject bindings.  
+   Commit: [Fix palette popover parenting and tray coordinates unpacking](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33/commits/9ff02a80)
+
+4. **Control Panel Dropdown Styling in `sugar-artwork`**  
+   Testing the Control Panel brought up contrast issues on GTK4 dropdown controls. Since `GtkDropDown` is an outer layout container in GTK4, applying styles directly to the top node left the inner buttons improperly rendered. Updating `gtk-widgets.css` to target `dropdown > button` and `combobox > button.combo` subnodes directly fixed the background contrast, while eliminating double borders on dropdown popover content nodes.  
+   Commit: [PR #132](https://github.com/sugarlabs/sugar-artwork/pull/132) - [gtk4/theme: fix control panel dropdown contrast and treeview row separators](https://github.com/sugarlabs/sugar-artwork/pull/132/commits/b4ee5ce)
+
+---
+
+## Challenges & How I Overcame Them
+
+- **Challenge:** Palette popovers were failing to appear without logging any error tracebacks in the console.  
+  **Solution:** I debugged `_PaletteMenuWidget.popup()` step by step and removed the native surface check that was preventing `set_parent()` from being reached.
+
+- **Challenge:** Broken allocation logic in `viewcontainer.py` was breaking container measurements in GTK4.  
+  **Solution:** I refactored the measurement implementation to use GTK4 `do_measure` and layout manager methods.
+
+---
+
+## Key Learnings
+
+- GTK4 popovers must explicitly invoke `set_parent()` on their invoker widget prior to popup display.
+- Styling `GtkDropDown` elements requires targeting inner button child nodes rather than applying styles directly to the outer container.
+
+---
+
+## Next Week's Roadmap
+
+- Resolve CSS scoping warnings in `sugar-toolkit-gtk4`.
+- Update activities list view cell renderer colors and favorite icon palette mapping in `sugar`.
+- Add missing check and radio row selection CSS states and treeview row separators in `sugar-artwork`.
+
+---
+
+## Resources & References
+
+- Sugar Shell Repository - [sugar](https://github.com/sugarlabs/sugar)
+- GTK4 Toolkit Library - [sugar-toolkit-gtk4](https://github.com/sugarlabs/sugar-toolkit-gtk4)
+- Documentation - [Read the Docs](https://sugar-toolkit-gtk4.readthedocs.io/en/latest/)
+- GTK4 Migration Guide - [GNOME Docs](https://docs.gtk.org/gtk4/migrating-3to4.html)
+- PyPI Package - [sugar-toolkit-gtk4](https://pypi.org/project/sugar-toolkit-gtk4/)
+- Sugar Ext Repository - [sugar-ext](https://github.com/sugarlabs/sugar-ext)
+- Casilda Compositor - [Casilda](https://gitlab.gnome.org/jpu/casilda/-/tree/main?ref_type=heads)
+- Sugar Artwork Repository - [sugar-artwork](https://github.com/sugarlabs/sugar-artwork)
+
+---
+
+## Acknowledgments
+
+Thanks to Krish and Ibiam for their feedback and reviews during testing.


### PR DESCRIPTION
The blog post covers end-to-end testing of the GTK4 Sugar shell, a live video walkthrough recording on GTK4 Wayland under Casilda, PR review feedback resolution for widget styling methods in `sugar`, palette popover parenting fixes in `sugar-toolkit-gtk4`, and control panel dropdown contrast updates in `sugar-artwork`.