### PR TITLE
docs: add GSoC '26 week 11 blog by Dev

### DIFF
--- a/src/constants/MarkdownFiles/posts/2026-08-09-gsoc-26-dev-week11.md
+++ b/src/constants/MarkdownFiles/posts/2026-08-09-gsoc-26-dev-week11.md
@@ -1,0 +1,88 @@
+---
+title: "GSoC '26 Week 11 Update by Dev"
+excerpt: "Fixing GTK4 CSS scoping and GTK4 CSS parser warnings in sugar-toolkit-gtk4, updating activities list cell rendering and icon palette styling in sugar, and completing theme selected states in sugar-artwork."
+category: "DEVELOPER NEWS"
+date: "2026-08-09"
+slug: "2026-08-09-gsoc-26-dev-week11"
+author: "@/constants/MarkdownFiles/authors/dev.md"
+tags: "gsoc26,sugarlabs,week11,dev,gtk4-port,Sugar shell"
+image: "assets/Images/GSOC.webp"
+---
+
+<!-- markdownlint-disable -->
+
+# Week 11 Progress Report by Dev
+
+**Project:** [GTK4 Transition Part 2: Sugar Shell](https://github.com/sugarlabs/GSoC/blob/master/Ideas-2026.md#gtk4-transition-part-2-sugar-shell)  
+**Mentors:** [Krish Pandya](https://github.com/MostlyKIGuess), [Ibiam Chihurumnaya](https://github.com/chimosky)  
+**Assisting Mentors:** [Walter Bender](https://github.com/walterbender), [Juan Pablo Ugarte](https://github.com/xjuan)  
+**Organization:** [Sugar Labs](https://sugarlabs.org)  
+**Reporting Period:** 2026-08-02 - 2026-08-08  
+
+---
+
+## Goals for This Week
+
+- **Goal 1:** Eliminate `Gtk-WARNING: No property named "button"` warnings produced by dynamic CSS injection in `sugar-toolkit-gtk4`.
+- **Goal 2:** Update cell renderer text colors and favorite icon stroke/fill styling in `sugar`'s Home Screen activities list.
+- **Goal 3:** Add missing check/radio row selection CSS states and treeview row separators in `sugar-artwork`.
+
+---
+
+## This Week's Achievements
+
+1. **Fixing CSS Scoping & Provider Warnings in `sugar-toolkit-gtk4`**  
+   While testing the shell, I noticed `Gtk-WARNING: No property named "button"` filling the terminal output whenever dynamic styles were applied to widgets. Investigating `apply_css_to_widget()` in `style.py` showed that it was wrapping incoming CSS strings in a `.sugar-dynamic-style-N` class block unconditionally. Passing full rule blocks like `button { ... }` produced nested selectors such as `.class { button { ... } }`, which GTK4's parser rejects as invalid properties. Updating `apply_css_to_widget()` to check if the CSS payload already contains `{` rule blocks solved the issue, allowing pre-formatted rules to pass directly to the provider. Additionally, provider management now caches `GtkCssProvider` instances per widget class via `widget.add_css_class()` instead of creating a new display-level provider on every map cycle, stopping provider leaks. I also fixed SVG icon stroke/fill property getters and ensured invoker event controllers are detached cleanly on window reparenting.  
+   Commits: [PR #33](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33) - [style: fix CSS scoping in apply_css_to_widget for GTK4 theme parser](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33/commits/077a58db) and [graphics: optimize per-widget CSS scoping and invoker controller teardown](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33/commits/6cd2006c)
+
+2. **Activities List Cell Rendering & Icon Color Palette in `sugar`**  
+   Auditing the Home Screen activities list (`ActivitiesTreeView`) revealed text color issues caused by hardcoded foreground attributes on cell renderers. Removing those hardcoded properties restored full stylesheet control over text color across list rows. At the same time, I updated favorite icon cell renderers to pull stroke and fill colors dynamically from the Sugar user color palette instead of static fallback values.  
+   Commits: [PR #1106](https://github.com/sugarlabs/sugar/pull/1106) - [desktop: update activities list cell rendering and icon styling](https://github.com/sugarlabs/sugar/pull/1106/commits/9b7eeb31)
+
+3. **Checkbox Visibility & Selected Row States in `sugar-artwork`**  
+   On the theme side, `checkbox-unchecked.svg` had `fill="none"` set on its main rect element, rendering unchecked checkboxes invisible against white backgrounds. Updating the attribute to `fill="&fill_color;"` matched the rest of the icon set. I also added missing CSS selectors for check and radio widgets on selected treeview rows (`check:selected`, `check:checked:selected`, `radio:selected`, `radio:checked:selected`) and restored row separators by applying `border-bottom: 1px solid #D0D0D0` to even and odd row selectors in `gtk-widgets.css`.  
+   Commits: [PR #132](https://github.com/sugarlabs/sugar-artwork/pull/132) - [gtk4/theme: fix checkbox fill and add missing selected check states](https://github.com/sugarlabs/sugar-artwork/pull/132/commits/4cd1b6f)
+
+---
+
+## Challenges & How I Overcame Them
+
+- **Challenge:** GTK4 CSS warnings gave no file locations or line numbers for the `No property named "button"` warning.  
+  **Solution:** I placed temporary debug logs inside `apply_css_to_widget()` to capture CSS strings before they reached the GTK parser, which revealed the double-wrapped selector structure.
+
+- **Challenge:** Unchecked checkboxes were invisible in the Journal list view.  
+  **Solution:** I inspected `checkbox-unchecked.svg` and replaced `fill="none"` with `fill="&fill_color;"`.
+
+---
+
+## Key Learnings
+
+- GTK4 CSS parser strictly forbids nested rule blocks; helper utilities must check for pre-existing selectors before scoping.
+- Restoring theme control over cell renderers requires stripping hardcoded foreground attributes from GTK treeview renderers.
+
+---
+
+## Next Week's Roadmap
+
+- Continue monitoring review feedback on open PRs across `sugar`, `sugar-toolkit-gtk4`, and `sugar-artwork`.
+- Perform further testing on activity launches over Casilda sockets.
+- Address any remaining edge-case regressions identified in the shell.
+
+---
+
+## Resources & References
+
+- Sugar Shell Repository - [sugar](https://github.com/sugarlabs/sugar)
+- GTK4 Toolkit Library - [sugar-toolkit-gtk4](https://github.com/sugarlabs/sugar-toolkit-gtk4)
+- Documentation - [Read the Docs](https://sugar-toolkit-gtk4.readthedocs.io/en/latest/)
+- GTK4 Migration Guide - [GNOME Docs](https://docs.gtk.org/gtk4/migrating-3to4.html)
+- PyPI Package - [sugar-toolkit-gtk4](https://pypi.org/project/sugar-toolkit-gtk4/)
+- Sugar Ext Repository - [sugar-ext](https://github.com/sugarlabs/sugar-ext)
+- Casilda Compositor - [Casilda](https://gitlab.gnome.org/jpu/casilda/-/tree/main?ref_type=heads)
+- Sugar Artwork Repository - [sugar-artwork](https://github.com/sugarlabs/sugar-artwork)
+
+---
+
+## Acknowledgments
+
+Thanks to Krish and Ibiam for their guidance and reviews.


### PR DESCRIPTION
The blog post details GTK4 CSS provider scoping optimizations and parser warning fixes in `sugar-toolkit-gtk4`, Home Screen activities list text color override removals and favorite icon palette styling in `sugar`, and missing SVG check/radio selected row states along with treeview row separators in `sugar-artwork`.