### PR TITLE
docs: add GSoC '26 week 12 blog by Dev

### DIFF
--- a/src/constants/MarkdownFiles/posts/2026-08-16-gsoc-26-dev-week12.md
+++ b/src/constants/MarkdownFiles/posts/2026-08-16-gsoc-26-dev-week12.md
@@ -1,0 +1,127 @@
+---
+title: "GSoC '26 Week 12 Update by Dev"
+excerpt: "Final audit across all four repositories, fixing leftover GTK3 API calls in sugar-ext C controllers, palette and tooltip regressions in sugar-toolkit-gtk4, Wayland activity launch and frame animation bugs in sugar, and CSS cleanup in sugar-artwork."
+category: "DEVELOPER NEWS"
+date: "2026-08-16"
+slug: "2026-08-16-gsoc-26-dev-week12"
+author: "@/constants/MarkdownFiles/authors/dev.md"
+tags: "gsoc26,sugarlabs,week12,dev,gtk4-port,Sugar shell"
+image: "assets/Images/GSOC.webp"
+---
+
+<!-- markdownlint-disable -->
+
+# Week 12 Progress Report by Dev
+
+**Project:** [GTK4 Transition Part 2: Sugar Shell](https://github.com/sugarlabs/GSoC/blob/master/Ideas-2026.md#gtk4-transition-part-2-sugar-shell)  
+**Mentors:** [Krish Pandya](https://github.com/MostlyKIGuess), [Ibiam Chihurumnaya](https://github.com/chimosky)  
+**Assisting Mentors:** [Walter Bender](https://github.com/walterbender), [Juan Pablo Ugarte](https://github.com/xjuan)  
+**Organization:** [Sugar Labs](https://sugarlabs.org)  
+**Reporting Period:** 2026-08-09 - 2026-08-17  
+
+---
+
+## Goals for This Week
+
+- **Goal 1:** Complete a final audit across all four repositories and fix any remaining GTK3-only API calls that slipped through previous passes.
+- **Goal 2:** Fix `sugar-ext` C event controller API incompatibilities and `sugar-toolkit-gtk4` palette rendering regressions.
+- **Goal 3:** Trace the Casilda Wayland compositor activity launch flow end to end and fix the outstanding Wayland activity launch and frame animation bugs in `sugar`.
+
+---
+
+## This Week's Achievements
+
+1. **GTK3 API Fixes in `sugar-ext` C Controllers**
+
+   Went through `sugar-ext` one more time and caught two bugs that would cause silent failures at runtime.
+
+   In `sugar-event-controller.c`, there was a `switch` case checking for `GDK_GRAB_BROKEN`. This event type does not exist in GTK4. Wayland handles input grab ownership at the compositor level and does not expose it to applications. Left in, it produces a compiler warning and potentially hits undefined behaviour on some toolchains. Replaced it with `GDK_TOUCH_CANCEL`, which is the correct signal when the compositor cancels a touch sequence.
+
+   In `sugar-swipe-controller.c`, the coordinate source was `gdk_event_get_axis()`, which was removed in GTK4 in favour of `gdk_event_get_position()`. Beyond the API fix, the handler was only matching `GDK_TOUCH_*` events, so mouse drag swipes were silently dropped. Added `GDK_BUTTON_PRESS`, `GDK_MOTION_NOTIFY`, and `GDK_BUTTON_RELEASE` cases so swipe recognition works for both touch and pointer input.
+
+   Commit: [controllers: fix GTK4 API compatibility in event and swipe controllers](https://github.com/sugarlabs/sugar-ext/pull/6/commits/eb11cc8c)
+
+2. **Palette Arrow, Escape Key, and Tool Button Tooltip Fixes in `sugar-toolkit-gtk4`**
+
+   Three palette regressions showed up while testing the shell this week.
+
+   The palette arrow was not rendering correctly from toolbar buttons. The arrow node was getting the wrong position class based on where the palette opens relative to its invoker. Fixed the placement logic to set `.left`, `.right`, `.top`, or `.bottom` correctly.
+
+   Pressing Escape to close a palette was silently failing. `Gtk.EventControllerKey` was connected but the handler was calling `popdown()` on the wrong widget instance. Fixed to call it on the correct one and release focus properly.
+
+   Tool button tooltips were not appearing because `set_has_tooltip(True)` was set on the inner button child instead of the outer `ToolButton` container. Moved it to the right widget.
+
+   Commit: [graphics: fix palette popover arrow display, Escape dismissal, and tool button tooltips](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33/commits/f8cd29c9)
+
+3. **Wayland Activity Launch, Window Focus, and Frame Animation in `sugar`**
+
+   Three bugs came up during end-to-end activity launch testing this week.
+
+   Activity windows launched over the Casilda socket were getting the wrong initial focus. The shell was calling `present()` before Casilda had finished mapping the surface, so focus fell through silently. Fixed by waiting for the `map` signal before calling `present()`.
+
+   The Frame animation was producing a single-frame flash when switching between `ZOOM_HOME` and `ZOOM_ACTIVITY`. It was a timing conflict between the Frame CSS transition and the `Gtk.Stack` page switch. Fixed by deferring the stack switch until the CSS transition completes using `GLib.idle_add`.
+
+   The active window indicator in the Frame was not updating correctly when switching between activities. Updated the focus handler in `shellwindow.py` to propagate focus changes to the Frame properly.
+
+   Commit: [jarabe: fix Wayland activity launch, window focus and frame animation](https://github.com/sugarlabs/sugar/pull/1106/commits/f84a2d51)
+
+4. **GTK4 CSS Cleanup in `sugar-artwork`**
+
+   Ran `GTK_DEBUG=css` while testing and got a bunch of parser warnings from `gtk4/theme/gtk.css`. Fixed three categories of issues.
+
+   Removed `-gtk-icon-style: regular` from the universal `*` selector, it does nothing there. Replaced six `alpha(@color, factor)` calls with `rgba()` since GTK4 marks the `alpha()` function deprecated and the values are identical as all the source colors are solid hex values. Replaced `-gtk-icon-size: 16px` on the combobox arrow node with `min-width: 16px; min-height: 16px`, which is how arrow node sizing actually works in GTK4.
+
+5. **Tracing the Casilda Activity Launch Flow**
+
+   Spent time this week going through how activities launch and embed inside the shell.
+
+   When an activity launches, `activityfactory.py` calls `shell.compositor.get_client_socket_fd()` to get a Wayland socket FD from the embedded Casilda compositor. That FD is passed to the child process through `pass_fds` and `WAYLAND_SOCKET`, and `DISPLAY` is unset in `main.py`. The activity connects directly to the shell's private Casilda display.
+
+   On the shell side, Casilda sits inside a `Gtk.Stack` next to the Home view. When an activity opens, `set_zoom_level(ZOOM_ACTIVITY)` switches the visible stack child. On close, `_remove_activity()` falls back to `ZOOM_HOME` if nothing else is open.
+
+   Tested this with activities that are migrated to GTK4 and they are working properly inside the shell.
+
+---
+
+## Challenges & How I Overcame Them
+
+- **Challenge:** I wasn't sure if the missing `GDK_GRAB_BROKEN` in GTK4 was a warning or an actual runtime hazard.  
+  **Solution:** Went through the GDK4 changelog and the GTK4 migration docs. The event type was fully removed because Wayland doesn't expose grab ownership to clients at all. `GDK_TOUCH_CANCEL` is the right substitute.
+
+- **Challenge:** The Frame animation jitter was intermittent and hard to reproduce consistently.  
+  **Solution:** Added print statements around the `set_zoom_level` and stack switch calls to capture exact timing, which showed the CSS transition was still running when the stack switched.
+
+---
+
+## Key Learnings
+
+- Running `GTK_DEBUG=css` is really useful for catching GTK4 CSS parser warnings that would otherwise be silent. Found all the `sugar-artwork` issues through this.
+- GTK3 activities work inside Casilda without modification because the Wayland socket handoff happens at the GDK level, not the toolkit level. Individual activity porting is just about updating widget code.
+- `present()` on a Casilda-backed window needs to wait for the `map` signal. Calling it before that causes focus to silently fail.
+
+---
+
+## Closing Thoughts
+
+This is the final week of GSoC and it has been a great experience working on the GTK4 migration of the Sugar Shell. The PRs for [sugar #1106](https://github.com/sugarlabs/sugar/pull/1106), [sugar-toolkit-gtk4 #33](https://github.com/sugarlabs/sugar-toolkit-gtk4/pull/33), and [sugar-ext #6](https://github.com/sugarlabs/sugar-ext/pull/6) are open. The migration work across all four repositories is complete. Next steps after GSoC will be addressing mentor review feedback, getting the PRs merged, and writing the final GSoC report covering the full scope of the migration.
+
+A big thanks to everyone at Sugar Labs for the support throughout the program!
+
+---
+
+## Resources & References
+
+- Sugar Shell Repository - [sugar](https://github.com/sugarlabs/sugar)
+- GTK4 Toolkit Library - [sugar-toolkit-gtk4](https://github.com/sugarlabs/sugar-toolkit-gtk4)
+- Documentation - [Read the Docs](https://sugar-toolkit-gtk4.readthedocs.io/en/latest/)
+- GTK4 Migration Guide - [GNOME Docs](https://docs.gtk.org/gtk4/migrating-3to4.html)
+- PyPI Package - [sugar-toolkit-gtk4](https://pypi.org/project/sugar-toolkit-gtk4/)
+- Sugar Ext Repository - [sugar-ext](https://github.com/sugarlabs/sugar-ext)
+- Casilda Compositor - [Casilda](https://gitlab.gnome.org/jpu/casilda/-/tree/main?ref_type=heads)
+- Sugar Artwork Repository - [sugar-artwork](https://github.com/sugarlabs/sugar-artwork)
+
+---
+
+## Acknowledgments
+
+Thanks to Krish Pandya, Ibiam Chihurumnaya, Walter Bender, and Juan Pablo Ugarte for their guidance and support throughout the project!


### PR DESCRIPTION
Adds the Week 12 GSoC progress report for the GTK4 Sugar Shell migration project.

Covers the final audit across all four repositories (sugar, sugar-toolkit-gtk4, sugar-ext, sugar-artwork), C controller API fixes in sugar-ext, palette and tooltip regressions in sugar-toolkit-gtk4, Wayland activity launch and frame animation fixes in sugar, and GTK4 CSS cleanup in sugar-artwork.